### PR TITLE
Fixed initial run and get nodeid

### DIFF
--- a/meshconsole/main.c
+++ b/meshconsole/main.c
@@ -164,6 +164,12 @@ char* crashMemory = ILib_POSIX_InstallCrashHandler(argv[0]);
 		integratedJavaScript = ILibString_Copy(script, sizeof(script) - 1);
 		integratedJavaScriptLen = (int)sizeof(script) - 1;
 	}
+	if (argc > 1 && strcasecmp(argv[1], "-nodeid-base64") == 0 && integratedJavaScriptLen == 0)
+	{
+		char script[] = "console.log(Buffer.from(require('_agentNodeId')(), 'hex').toString('base64').replace(/\\+/g, '@').replace(/\\//g, '$'));process.exit();";
+		integratedJavaScript = ILibString_Copy(script, sizeof(script) - 1);
+		integratedJavaScriptLen = (int)sizeof(script) - 1;
+	}
 	if (argc > 1 && strcasecmp(argv[1], "-name") == 0 && integratedJavaScriptLen == 0)
 	{
 		char script[] = "console.log(require('_agentNodeId').serviceName());process.exit();";

--- a/microscript/ILibDuktape_Commit.h
+++ b/microscript/ILibDuktape_Commit.h
@@ -1,3 +1,3 @@
 // This file is auto-generated, any edits may be overwritten
-#define SOURCE_COMMIT_DATE "2025-Sep-16 20:37:19+0200"
-#define SOURCE_COMMIT_HASH "d956d6a0a144a6507e0cd73dc4fff66406ac7b6f"
+#define SOURCE_COMMIT_DATE "2025-Sep-16 23:00:19+0200"
+#define SOURCE_COMMIT_HASH "5645b461aa143660e9f8eae1e6d724ccc3837be4"


### PR DESCRIPTION
**Summary**
Added mode to retrieve node ID from the local database.
Fixed issue where the MeshCentral core module failed to run during the first MeshAgent launch.

**Details**
Previously, when MeshAgent was run for the first time, it could not correctly start the local core module. As a result, users were unable to establish a remote connection until after restarting the agent, at which point everything worked correctly.
The root cause was that the flow on the first run used a different method than subsequent runs. The required logic was missing in the initial method. This has been fixed by duplicating the necessary logic into the first-run method.