### PR TITLE
Update macOS signing pipeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Description
+<!-- Provide a clear, concise description of what this PR changes -->
+
+## Improvements
+- <!-- Step by step improvements -->
+- 
+
+## Task
+[Link](https://app.clickup.com/t/example)
+<!-- Links to any related tickets, issues, or requirements -->

--- a/.github/steps/sign-macos-package/action.yml
+++ b/.github/steps/sign-macos-package/action.yml
@@ -1,5 +1,5 @@
 name: Sign MacOS package
-description: Sign built MacOS package and Notarize it
+description: Sign built universal MacOS package and Notarize it
 inputs:
   apple_certificate_p12:
     description: 'Base64 encoded Apple Developer certificate (.p12)'
@@ -20,13 +20,8 @@ inputs:
     description: 'Apple Developer ID'
     required: true
   binary_name:
-    description: 'Name of built MacOS binary (e.g. "rmmagent-mac-universal")'
+    description: 'Name of built MacOS binary (e.g. "rmmagent")'
     required: true
-    default: ""
-  app_name:
-    description: 'Name of MacOS App targets to add (e.g. "RMMAgent")'
-    required: true
-    default: ""
 
 runs:
   using: "composite"
@@ -35,14 +30,10 @@ runs:
       shell: bash
       run: |
         BINARY_NAME="${{ inputs.binary_name }}"
-        APP_NAME="${{ inputs.app_name }}"
-        APP_BUNDLE="${APP_NAME}.app"
         BINARY_PATH="./artifacts/$BINARY_NAME"
         DEVELOPER_ID="${{ inputs.apple_developer_id }}"
 
         echo "BINARY_NAME=$BINARY_NAME"  >> $GITHUB_ENV
-        echo "APP_NAME=$APP_NAME" >> $GITHUB_ENV
-        echo "APP_BUNDLE=$APP_BUNDLE" >> $GITHUB_ENV
         echo "BINARY_PATH=$BINARY_PATH" >> $GITHUB_ENV
         echo "DEVELOPER_ID=$DEVELOPER_ID" >> $GITHUB_ENV
 
@@ -67,99 +58,43 @@ runs:
         rm "$CERTIFICATE_PATH"
         echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
 
-    - name: Code Sign Binary
+    - name: Code Sign Standalone binary
       shell: bash
       run: |
-        to_lower() {
-          # Lowercase regardless of input
-          printf '%s' "$*" | tr '[:upper:]' '[:lower:]'
-        }
-        APP_NAME_LOWER="$(to_lower $APP_NAME)"
-        BUNDLE_ID="cx.flamingo.$APP_NAME_LOWER"
-
-        # Clean up any existing bundle and create new app bundle structure
-        rm -rf "$APP_BUNDLE" "${APP_BUNDLE}.zip"
-        mkdir -p "${APP_BUNDLE}/Contents/MacOS"
-        mkdir -p "${APP_BUNDLE}/Contents/Resources"
-        cp "$BINARY_PATH" "${APP_BUNDLE}/Contents/MacOS/${APP_NAME}"
-        chmod +x "${APP_BUNDLE}/Contents/MacOS/${APP_NAME}"
-        
-        # Create Info.plist and entitlements
-        cat > "${APP_BUNDLE}/Contents/Info.plist" << EOF
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-            <key>CFBundleExecutable</key>
-            <string>${APP_NAME}</string>
-            <key>CFBundleIdentifier</key>
-            <string>${BUNDLE_ID}</string>
-            <key>CFBundleName</key>
-            <string>${APP_NAME}</string>
-            <key>CFBundleDisplayName</key>
-            <string>${APP_NAME}</string>
-            <key>CFBundleVersion</key>
-            <string>1.0.0</string>
-            <key>CFBundleShortVersionString</key>
-            <string>1.0.0</string>
-            <key>CFBundleInfoDictionaryVersion</key>
-            <string>6.0</string>
-            <key>CFBundlePackageType</key>
-            <string>APPL</string>
-            <key>CFBundleSignature</key>
-            <string>????</string>
-            <key>LSMinimumSystemVersion</key>
-            <string>10.15</string>
-            <key>NSHighResolutionCapable</key>
-            <true/>
-            <key>LSUIElement</key>
-            <true/>
-            <key>LSBackgroundOnly</key>
-            <true/>
-        </dict>
-        </plist>
-        EOF
-        
-        cat > "entitlements.plist" << EOF
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-            <key>com.apple.security.cs.disable-library-validation</key><true/>
-        </dict>
-        </plist>
-        EOF
+        chmod +x "$BINARY_PATH"
 
         # Sign the binary and verify
-        codesign --sign "$DEVELOPER_ID" --timestamp --options runtime --entitlements "entitlements.plist" --deep --force "$APP_BUNDLE"
+        codesign --sign "$DEVELOPER_ID" --timestamp --options runtime --deep --force "$BINARY_PATH"
         
         # Verify signature
-        codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+        codesign --verify --deep --strict --verbose=2 "$BINARY_PATH"
+        codesign -dv --verbose=4 "$BINARY_PATH"
         echo "Binary signed successfully"
 
     - name: Create archive and submit for Notarization
       shell: bash
       run: |
-        zip -r "${APP_BUNDLE}.zip" "$APP_BUNDLE"
+        zip "${BINARY_NAME}.zip" -j "$BINARY_PATH"
 
-        xcrun notarytool submit "${APP_BUNDLE}.zip" \
+        echo "Submitting binary for notarization..."
+        xcrun notarytool submit "${BINARY_NAME}.zip" \
           --apple-id "${{ inputs.apple_id_username }}" \
           --password "${{ inputs.apple_id_password }}" \
           --team-id "${{ inputs.apple_team_id }}" \
           --wait \
           --timeout 30m
 
-    - name: Staple Notarization Ticket and Verify Final Binary
+        # Cleanup zip
+        rm "${BINARY_NAME}.zip"
+        echo "Notarization completed successfully"          
+
+    - name: Verify Final Binary
       shell: bash
       run: |
-        xcrun stapler staple "$APP_BUNDLE"
-        xcrun stapler validate "$APP_BUNDLE"
-        echo "Notarization completed successfully"
-
         # Verify code signature and notarization
-        codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
-        spctl --assess --type execute --verbose "$APP_BUNDLE"
-        echo "Binary verification completed"
+        codesign --verify --deep --strict --verbose=2 "$BINARY_PATH"
+        spctl --assess --type open --context context:primary-signature --verbose "$BINARY_PATH" || true
+        echo "Binary is signed, notarized, and ready for distribution"
 
     - name: Cleanup Keychain
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,8 +169,8 @@ jobs:
       - name: Create Universal Binary
         run: |
           echo "Creating universal macOS binary with lipo..."
-          X64_BINARY="x64-artifacts/meshagent_osx-x86-64"
-          ARM64_BINARY="arm64-artifacts/meshagent_osx-arm-64"
+          X64_BINARY="x64-artifacts/${{ env.BINARY_NAME }}"
+          ARM64_BINARY="arm64-artifacts/${{ env.BINARY_NAME }}"
           
           mkdir -p artifacts
           lipo -create "$X64_BINARY" "$ARM64_BINARY" -output ./artifacts/${{ env.BINARY_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   push:
-    branches: [master]
+    branches: [master, feature/update-macos-signing-pipeline]
     paths-ignore:
       - "**/*.md"
   workflow_dispatch:
@@ -24,6 +24,7 @@ env:
   REGISTRY: "ghcr.io"
   ORGANISATION: ${{ github.repository_owner }}
   REPOSITORY: ${{ github.event.repository.name }}
+  BINARY_NAME: meshagent
 
 # =============================================================================
 # JOBS
@@ -56,13 +57,7 @@ jobs:
             os: windows-latest
             os_arch: x64
             archid: 4
-            artifact_name: meshagent-windows-x64.exe
-###          - name: "Windows x86"
-###            os: windows-latest
-###            os_arch: x86
-###            archid: 3
-###            artifact_name: meshagent-windows-x86.exe
-
+            artifact_name: meshagent-windows-x64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,36 +92,43 @@ jobs:
         shell: bash
 
       - name: Prepare Artifacts
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          mkdir -p artifacts          
-          if [[ "${{ matrix.os_arch }}" == "arm64" ]]; then
-            BINARY_NAME="meshagent_osx-arm-64"
-          elif [[ "${{ matrix.os_arch }}" == "x86-64" ]]; then
-            BINARY_NAME="meshagent_osx-x86-64"
-          fi
-          cp "$BINARY_NAME" "artifacts/"
-
-      - name: Prepare Windows Artifacts
-        if: runner.os == 'Windows'
         shell: bash
         run: |
           mkdir -p artifacts
-          if [[ -f "Release/MeshService64.exe" ]]; then
-            cp "Release/MeshService64.exe" "artifacts/meshagent-windows-${{ matrix.os_arch }}.exe"
-            echo "Found and copied: Release/MeshService64.exe"
-          elif [[ -f "x64/Release/MeshService64.exe" ]]; then
-            cp "x64/Release/MeshService64.exe" "artifacts/meshagent-windows-${{ matrix.os_arch }}.exe"
-            echo "Found and copied: x64/Release/MeshService64.exe"
+          
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            if [[ -f "Release/MeshService64.exe" ]]; then
+              cp "Release/MeshService64.exe" "artifacts/${{ env.BINARY_NAME }}.exe"
+              echo "Copied Windows binary"
+            else
+              echo "MeshService64.exe not found, checking available files:"
+              find . -name "*.exe" -type f | head -10
+              exit 1
+            fi
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            if [[ "${{ matrix.os_arch }}" == "arm64" ]]; then
+              BUILT_BINARY_NAME="meshagent_osx-arm-64"
+            elif [[ "${{ matrix.os_arch }}" == "x86-64" ]]; then
+              BUILT_BINARY_NAME="meshagent_osx-x86-64"
+            else
+              echo "Unknown macOS architecture: ${{ matrix.os_arch }}"
+              exit 1
+            fi
+            if [[ -f "$BUILT_BINARY_NAME" ]]; then
+              cp "$BUILT_BINARY_NAME" "artifacts/${{ env.BINARY_NAME }}"
+              echo "Copied macOS binary: $BUILT_BINARY_NAME"
+            else
+              echo "$BUILT_BINARY_NAME not found"
+              ls -la meshagent* || echo "No meshagent files found"
+              exit 1
+            fi
           else
-            echo "MeshService64.exe not found, checking available files:"
-            find . -name "*.exe" -type f | head -10
+            echo "Unsupported OS: ${{ runner.os }}"
             exit 1
           fi
           
-          # List what we're uploading
-          ls -la artifacts/
+          echo "Artifacts prepared:"
+          ls -la artifacts/          
 
       - name: Upload client artifact
         uses: actions/upload-artifact@v4
@@ -166,18 +168,17 @@ jobs:
 
       - name: Create Universal Binary
         run: |
-          echo "Creating universal macOS binary..."
+          echo "Creating universal macOS binary with lipo..."
           X64_BINARY="x64-artifacts/meshagent_osx-x86-64"
           ARM64_BINARY="arm64-artifacts/meshagent_osx-arm-64"
           
-          echo "Creating universal binary with lipo..."
           mkdir -p artifacts
-          lipo -create "$X64_BINARY" "$ARM64_BINARY" -output ./artifacts/meshagent-osx-universal
+          lipo -create "$X64_BINARY" "$ARM64_BINARY" -output ./artifacts/${{ env.BINARY_NAME }}
           
           # Verify universal binary
           echo "Universal binary info:"
-          lipo -info ./artifacts/meshagent-osx-universal
-          file ./artifacts/meshagent-osx-universal
+          lipo -info ./artifacts/${{ env.BINARY_NAME }}
+          file ./artifacts/${{ env.BINARY_NAME }}
           
       - name: Sign MacOS package
         uses: ./.github/steps/sign-macos-package
@@ -188,9 +189,7 @@ jobs:
           apple_id_username: ${{ secrets.APPLE_ID_USERNAME }}
           apple_id_password: ${{ secrets.APPLE_ID_PASSWORD }}
           apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
-          binary_name: meshagent-osx-universal
-          app_name: MeshAgent
-
+          binary_name: ${{ env.BINARY_NAME }}
 
       - name: Upload Universal Binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   push:
-    branches: [master, feature/update-macos-signing-pipeline]
+    branches: [master]
     paths-ignore:
       - "**/*.md"
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,6 @@ on:
     branches: [master]
     paths-ignore:
       - "**/*.md"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to release (e.g., v1.2.3)"
-        required: true
-        type: string
 
 concurrency:
   group: pr-${{ github.head_ref || github.ref }}
@@ -39,7 +33,7 @@ jobs:
     name: "Build C Client (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     if: |
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft) || github.event_name == 'workflow_dispatch'
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     defaults:
       run:
         shell: bash
@@ -61,13 +55,7 @@ jobs:
             os: windows-latest
             os_arch: x64
             archid: 4
-            artifact_name: meshagent-windows-x64.exe
-###          - name: "Windows x86"
-###            os: windows-latest
-###            os_arch: x86
-###            archid: 3
-###            artifact_name: meshagent-windows-x86.exe
-
+            artifact_name: meshagent-windows-x64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,98 +88,3 @@ jobs:
           echo "Building MeshAgent for macOS ${{ matrix.os_arch }}"
           make macos ARCHID=${{ matrix.archid }}
         shell: bash
-
-      - name: Prepare Artifacts
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          mkdir -p artifacts          
-          if [[ "${{ matrix.os_arch }}" == "arm64" ]]; then
-            BINARY_NAME="meshagent_osx-arm-64"
-          elif [[ "${{ matrix.os_arch }}" == "x86-64" ]]; then
-            BINARY_NAME="meshagent_osx-x86-64"
-          fi
-          cp "$BINARY_NAME" "artifacts/"
-
-      - name: Prepare Windows Artifacts
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          mkdir -p artifacts
-          if [[ -f "Release/MeshService64.exe" ]]; then
-            cp "Release/MeshService64.exe" "artifacts/meshagent-windows-${{ matrix.os_arch }}.exe"
-            echo "Found and copied: Release/MeshService64.exe"
-          elif [[ -f "x64/Release/MeshService64.exe" ]]; then
-            cp "x64/Release/MeshService64.exe" "artifacts/meshagent-windows-${{ matrix.os_arch }}.exe"
-            echo "Found and copied: x64/Release/MeshService64.exe"
-          else
-            echo "MeshService64.exe not found, checking available files:"
-            find . -name "*.exe" -type f | head -10
-            exit 1
-          fi
-          
-          # List what we're uploading
-          ls -la artifacts/
-
-      - name: Upload client artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact_name }}
-          path: |
-            artifacts/
-          if-no-files-found: warn
-          retention-days: 30
-          compression-level: 9
-
-  create_universal_macos:
-    name: "Create Universal macOS Binary"
-    needs: [build_client]
-    runs-on: macos-latest
-    if: |
-      ((github.event_name == 'pull_request' && !github.event.pull_request.draft) || github.event_name == 'workflow_dispatch') &&
-      !failure() && !cancelled()
-    
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Download macOS x86-64 Binary
-        uses: actions/download-artifact@v4
-        with:
-          name: meshagent_osx-x86-64
-          path: x64-artifacts/
-
-      - name: Download macOS ARM64 Binary
-        uses: actions/download-artifact@v4
-        with:
-          name: meshagent_osx-arm-64
-          path: arm64-artifacts/
-
-      - name: Create Universal Binary
-        run: |
-          echo "Creating universal macOS binary..."
-          X64_BINARY="x64-artifacts/meshagent_osx-x86-64"
-          ARM64_BINARY="arm64-artifacts/meshagent_osx-arm-64"
-          
-          echo "Creating universal binary with lipo..."
-          mkdir -p artifacts
-          lipo -create "$X64_BINARY" "$ARM64_BINARY" -output ./artifacts/meshagent-osx-universal
-          
-          # Verify universal binary
-          echo "Universal binary info:"
-          lipo -info ./artifacts/meshagent-osx-universal
-          file ./artifacts/meshagent-osx-universal
-          
-      - name: Sign MacOS package
-        uses: ./.github/steps/sign-macos-package
-        with:
-          apple_certificate_p12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
-          apple_certificate_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          apple_developer_id: ${{ secrets.APPLE_DEVELOPER_ID }}
-          apple_id_username: ${{ secrets.APPLE_ID_USERNAME }}
-          apple_id_password: ${{ secrets.APPLE_ID_PASSWORD }}
-          apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
-          binary_name: meshagent-osx-universal
-          app_name: MeshAgent


### PR DESCRIPTION
Switch from signing macOS App bundle to signing distributed binary itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors CI to create a universal macOS binary and sign/notarize the standalone binary, unifying artifact handling and simplifying the test workflow.
> 
> - **CI/Workflows**:
>   - **Build**:
>     - Standardize artifact naming with `env.BINARY_NAME` (`meshagent`) and unify artifact preparation across Windows/macOS.
>     - Create universal macOS binary as `artifacts/meshagent` via `lipo`; update signing step to use the local action with `binary_name` only.
>     - Adjust Windows artifact name (remove `.exe` suffix in artifact name).
>   - **Test**:
>     - Limit trigger to PRs only; remove artifact upload and the universal macOS job.
> - **Signing Action (`.github/steps/sign-macos-package/action.yml`)**:
>   - Switch from building/signing an app bundle to signing the standalone binary; zip binary for notarization; update verification; drop stapling.
>   - Simplify inputs (remove `app_name`; update `binary_name` example) and revise description.
> - **Repo Meta**:
>   - Add PR template at `.github/PULL_REQUEST_TEMPLATE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f967728331f4e22a7a7f6115b7afc3fd56803470. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->