### PR TITLE
Avoid node id change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   push:
-    branches: [master,feture/avoid-node-id-change]
+    branches: [master]
     paths-ignore:
       - "**/*.md"
   workflow_dispatch:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Skip and ignore NodeID reset logic in OpenFrame mode; clarify that JWT auth token is only available in OpenFrame mode.
> 
> - **OpenFrame mode**:
>   - Prevent NodeID resets: skip MAC-based reset checks and ignore any reset requests when `openFrameMode` is enabled (`meshcore/agentcore.c`).
> - **Auth token**:
>   - Clarify log message: JWT token is only available in OpenFrame mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cec93e2dd7706dcc7699bfc65ad2b51b6a08456. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->