### PR TITLE
test: no-op comment to confirm Windows CI failure is environmental

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// CI control test: no-op comment to verify the Windows build failure is environmental (runner image), not code.
+
 #ifdef WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
**Control experiment for PR #53.**

This branch is plain `master` + a single comment in `agentcore.c` — **none** of the diagnostic logging from #53.

If this PR's `Build C Client (windows-latest)` job also fails with:
```
MeshService.rc(10): fatal error RC1015: cannot open include file 'afxres.h'
```
then that failure is caused by the GitHub `windows-latest` runner migrating to the Visual Studio 2026 image (June 8–15, 2026), which removed MFC — and is unrelated to #53's code.

Do not merge — diagnostic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)