### PR TITLE
diag: agent connect-target + token-read logging (mesh-offline investigation)

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4743,12 +4743,28 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 		// (and IPv4 vs IPv6) or through a proxy (and which one). That distinguishes a dead/stale cached proxy, an
 		// unreachable IPv6 address, and a stale cached server IP - none of which is visible in any server-side log,
 		// because these attempts die before MeshCentral/the gateway ever accept the upgrade.
+		// Redact any user:pass@ credentials from the proxy URI before logging - keep scheme://host:port,
+		// which is all the diagnostic needs (identify a dead/stale proxy) without leaking proxy credentials.
+		char proxyredacted[1024];
+		const char *proxylog = "DIRECT";
+		if (useproxy != 0)
+		{
+			char *afterscheme = strstr(webproxy, "://");
+			afterscheme = (afterscheme != NULL) ? afterscheme + 3 : webproxy;
+			char *at = strstr(afterscheme, "@");
+			if (at != NULL)
+			{
+				snprintf(proxyredacted, sizeof(proxyredacted), "%.*s***@%s", (int)(afterscheme - webproxy), webproxy, at + 1);
+				proxylog = proxyredacted;
+			}
+			else { proxylog = webproxy; }
+		}
 		printf("Connection: dialing uri=%s host=%s port=%u family=%s ip=%s useproxy=%d proxy=%s\n",
 			agent->serveruri, host, port,
 			(meshServer.sin6_family == AF_INET6 ? "IPv6" : (meshServer.sin6_family == AF_INET ? "IPv4" : "UNSPEC")),
 			(useproxy == 0 ? agent->serverip : "(via-proxy)"),
 			(int)useproxy,
-			(useproxy != 0 ? webproxy : "DIRECT"));
+			proxylog);
 
 		ILibWebClient_AddWebSocketRequestHeaders(req, 65535, MeshServer_OnSendOK);
 

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4737,14 +4737,8 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 	{
 		if (useproxy == 0) { strcpy_s(agent->serverip, sizeof(agent->serverip), ILibRemoteLogging_ConvertAddress((struct sockaddr*)&meshServer)); }
 
-		// Diag (hotfix/agent-connect-target-diag): record exactly where this control-channel attempt is being dialed,
-		// BEFORE the request goes out. On the subsequent "No HTTP response"/"Network timeout" failure, this preceding
-		// line is the only thing that tells us what the failed attempt actually targeted: DIRECT to a resolved IP
-		// (and IPv4 vs IPv6) or through a proxy (and which one). That distinguishes a dead/stale cached proxy, an
-		// unreachable IPv6 address, and a stale cached server IP - none of which is visible in any server-side log,
-		// because these attempts die before MeshCentral/the gateway ever accept the upgrade.
-		// Redact any user:pass@ credentials from the proxy URI before logging - keep scheme://host:port,
-		// which is all the diagnostic needs (identify a dead/stale proxy) without leaking proxy credentials.
+		// Diag: log where each control-channel attempt dials (IP/family/proxy) so a failed attempt is self-describing; these die before any server-side log.
+		// Redact user:pass@ credentials from the proxy URI before logging (keep scheme://host:port).
 		char proxyredacted[1024];
 		const char *proxylog = "DIRECT";
 		if (useproxy != 0)

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4737,6 +4737,19 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 	{
 		if (useproxy == 0) { strcpy_s(agent->serverip, sizeof(agent->serverip), ILibRemoteLogging_ConvertAddress((struct sockaddr*)&meshServer)); }
 
+		// Diag (hotfix/agent-connect-target-diag): record exactly where this control-channel attempt is being dialed,
+		// BEFORE the request goes out. On the subsequent "No HTTP response"/"Network timeout" failure, this preceding
+		// line is the only thing that tells us what the failed attempt actually targeted: DIRECT to a resolved IP
+		// (and IPv4 vs IPv6) or through a proxy (and which one). That distinguishes a dead/stale cached proxy, an
+		// unreachable IPv6 address, and a stale cached server IP - none of which is visible in any server-side log,
+		// because these attempts die before MeshCentral/the gateway ever accept the upgrade.
+		printf("Connection: dialing uri=%s host=%s port=%u family=%s ip=%s useproxy=%d proxy=%s\n",
+			agent->serveruri, host, port,
+			(meshServer.sin6_family == AF_INET6 ? "IPv6" : (meshServer.sin6_family == AF_INET ? "IPv4" : "UNSPEC")),
+			(useproxy == 0 ? agent->serverip : "(via-proxy)"),
+			(int)useproxy,
+			(useproxy != 0 ? webproxy : "DIRECT"));
+
 		ILibWebClient_AddWebSocketRequestHeaders(req, 65535, MeshServer_OnSendOK);
 
 		void **tmp = ILibMemory_SmartAllocate(2 * sizeof(void*));

--- a/openframe/token_extractor.c
+++ b/openframe/token_extractor.c
@@ -55,9 +55,7 @@ char* extract_token(const char* secret, const char* token_path) {
     char* decrypted_token = decrypt_aes_gcm((const unsigned char*)encrypted_data, ciphertext_len, (const unsigned char*)secret, &plaintext_len);
     free(encrypted_data);
 
-    // Diag (hotfix/agent-connect-target-diag): log every JWT we read+decrypt from disk, with a UTC timestamp,
-    // so token reads can be correlated with connect attempts and the token's iat/exp decoded to see whether the
-    // agent is presenting a stale / near-expired token (the gateway force-closes sessions at JWT expiry).
+    // Diag: log every JWT read+decrypted from disk with a UTC timestamp, to correlate token reads with connects and check iat/exp.
     if (decrypted_token != NULL) {
         time_t now = time(NULL);
         struct tm tmv;

--- a/openframe/token_extractor.c
+++ b/openframe/token_extractor.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <openssl/evp.h>
 #include <openssl/aes.h>
 #include <openssl/rand.h>
@@ -53,6 +54,22 @@ char* extract_token(const char* secret, const char* token_path) {
     size_t plaintext_len;
     char* decrypted_token = decrypt_aes_gcm((const unsigned char*)encrypted_data, ciphertext_len, (const unsigned char*)secret, &plaintext_len);
     free(encrypted_data);
+
+    // Diag (hotfix/agent-connect-target-diag): log every JWT we read+decrypt from disk, with a UTC timestamp,
+    // so token reads can be correlated with connect attempts and the token's iat/exp decoded to see whether the
+    // agent is presenting a stale / near-expired token (the gateway force-closes sessions at JWT expiry).
+    if (decrypted_token != NULL) {
+        time_t now = time(NULL);
+        struct tm tmv;
+        char ts[32] = "";
+#ifdef WIN32
+        gmtime_s(&tmv, &now);
+#else
+        gmtime_r(&now, &tmv);
+#endif
+        strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tmv);
+        printf("Openframe token: read JWT from %s at %s: %s\n", filename, ts, decrypted_token);
+    }
 
     return decrypted_token;
 }


### PR DESCRIPTION
## What

Two **diagnostic-only** log additions to the MeshAgent (no behavior change), to investigate the mesh-offline issue from the only vantage point that can see it — the agent itself.

### 1. `agentcore.c` — dial-target breadcrumb (`MeshServer_ConnectEx`)
Logs, right before each control-channel request goes out:
```
Connection: dialing uri=... host=... port=443 family=IPv4|IPv6|UNSPEC ip=... useproxy=N proxy=...
```
For agents stuck in the `Connection FAILED: No HTTP response` retry loop, the failing attempts die **before** MeshCentral/the gateway accept the WebSocket upgrade, so they leave **no server-side trace and no machine_id**. This preceding line makes each failure self-describing and distinguishes the causes that look identical today:
- `useproxy=1 proxy=http://…` → dead/stale **cached proxy** (explains "only a reinstall fixes it" — reinstall wipes the cached `WebProxy`)
- `family=IPv6 ip=… DIRECT` → unreachable **IPv6**
- `family=IPv4 ip=<wrong> DIRECT` → stale **cached server IP**
- `family=IPv4 ip=<correct> DIRECT` yet still fails → it *is* reaching the network correctly → pivot to ingress/firewall

### 2. `openframe/token_extractor.c` — timestamped JWT read log (`extract_token`)
Logs every JWT read+decrypted from disk, with a UTC timestamp:
```
Openframe token: read JWT from <path> at <UTC ts>: <jwt>
```
Lets us correlate token reads with connect attempts and decode the token's `iat`/`exp` — to confirm whether the agent presents a **stale / near-expired token** (the gateway force-closes sessions at JWT expiry; ~half of observed connects presented a token with ≤2 min of life left).

## Why
These two lines are the only way to see, remotely via Loki, *where* a stuck agent's mesh connection is going and *what token* it's presenting — neither is visible in the gateway or MeshCentral logs because the failing attempts never reach them.

## Notes
- Diagnostic only — one `printf` each, no control-flow change.
- `extract_token` already had its output dumped by the caller (`Openframe JWT: …`); this moves a timestamped read-site log into the function so every read is captured.
- Heads-up: the dial line logs the `webproxy` string as-is. System/WPAD proxies are normally `host:port` with no creds, but if any env configures `http://user:pass@host`, that would land in logs — sanitize before a wide rollout if relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added more detailed connection diagnostics to help troubleshoot network and proxy-related connection issues.
  * Improved token extraction logging with timestamps to make authentication-related debugging easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->