### PR TITLE
diag: enrich control-channel failure logs with tls/elapsed/attempt-id

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4305,10 +4305,12 @@ void MeshServer_OnResponse(ILibWebClient_StateObject WebStateObject, int Interru
 		ILibRemoteLogging_printf(ILibChainGetLogger(ILibWebClient_GetChainFromWebStateObject(WebStateObject)), ILibRemoteLogging_Modules_Agent_GuardPost, ILibRemoteLogging_Flags_VerbosityLevel_1, "Agent Host Container: Mesh Server Connection Error, trying again later.");
 
 		long long elapsedMs = ILibGetUptime() - agent->controlChannelDialTick;
+		// tls is only meaningful for wss; the ConnectSink flag tracks plain TCP connect on ws.
+		const char *tlsState = (strncmp("wss:", agent->serveruri, 4) != 0) ? "n/a" : (agent->controlChannelTlsUp != 0 ? "up" : "down");
 		printf("Connection FAILED: No HTTP response (fd=%d, status=%s, authState=%d, connState=%d, tls=%s, elapsedMs=%lld, attempt=%s)\n",
 			ILibWebClient_GetDescriptorValue_FromStateObject(WebStateObject),
 			recvStatusStr, agent->serverAuthState, agent->serverConnectionState,
-			(agent->controlChannelTlsUp != 0 ? "up" : "down"), elapsedMs, agent->connectAttemptId);
+			tlsState, elapsedMs, agent->connectAttemptId);
 
 		agent->autoproxy_status = 0;
 
@@ -4346,8 +4348,10 @@ void MeshServer_ConnectEx_NetworkError(void *j)
 
 	if (agent->controlChannelDebug != 0) { printf("Network Timeout Occurred...\n"); }
 	long long elapsedMs = ILibGetUptime() - agent->controlChannelDialTick;
+	// tls is only meaningful for wss; the ConnectSink flag tracks plain TCP connect on ws.
+	const char *tlsState = (strncmp("wss:", agent->serveruri, 4) != 0) ? "n/a" : (agent->controlChannelTlsUp != 0 ? "up" : "down");
 	printf("Connection FAILED: Network timeout - server unreachable or gateway blocking (tls=%s, elapsedMs=%lld, attempt=%s)\n",
-		(agent->controlChannelTlsUp != 0 ? "up" : "down"), elapsedMs, agent->connectAttemptId);
+		tlsState, elapsedMs, agent->connectAttemptId);
 	agent->serverConnectionState = 0;
 
 	ILibWebClient_CancelRequest(request);
@@ -4397,7 +4401,7 @@ duk_ret_t MeshServer_ConnectEx_AutoProxy(duk_context *ctx)
 
 void MeshServer_ControlChannel_ConnectSink(ILibWebClient_RequestToken sender)
 {
-	// Fires after TCP connect + TLS handshake, before the HTTP upgrade is sent.
+	// Fires after TCP connect (and TLS handshake for wss), before the HTTP upgrade is sent.
 	void **uo = ILibWebClient_RequestToken_GetUserObjects(sender);
 	MeshAgentHostContainer *agent = (uo != NULL) ? (MeshAgentHostContainer*)uo[0] : NULL;
 	if (agent != NULL) { agent->controlChannelTlsUp = 1; }

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4410,7 +4410,7 @@ void MeshServer_ControlChannel_ConnectSink(ILibWebClient_RequestToken sender)
 	// Fires after TCP connect (and TLS handshake for wss), before the HTTP upgrade is sent.
 	void **uo = ILibWebClient_RequestToken_GetUserObjects(sender);
 	MeshAgentHostContainer *agent = (uo != NULL) ? (MeshAgentHostContainer*)uo[0] : NULL;
-	if (agent != NULL) { agent->controlChannelTlsUp = 1; }
+	if (agent != NULL && strncmp("wss:", agent->serveruri, 4) == 0) { agent->controlChannelTlsUp = 1; }
 }
 
 void MeshServer_ConnectEx(MeshAgentHostContainer *agent)

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4304,13 +4304,16 @@ void MeshServer_OnResponse(ILibWebClient_StateObject WebStateObject, int Interru
 		}
 		ILibRemoteLogging_printf(ILibChainGetLogger(ILibWebClient_GetChainFromWebStateObject(WebStateObject)), ILibRemoteLogging_Modules_Agent_GuardPost, ILibRemoteLogging_Flags_VerbosityLevel_1, "Agent Host Container: Mesh Server Connection Error, trying again later.");
 
-		long long elapsedMs = ILibGetUptime() - agent->controlChannelDialTick;
-		// tls is only meaningful for wss; the ConnectSink flag tracks plain TCP connect on ws.
-		const char *tlsState = (strncmp("wss:", agent->serveruri, 4) != 0) ? "n/a" : (agent->controlChannelTlsUp != 0 ? "up" : "down");
-		printf("Connection FAILED: No HTTP response (fd=%d, status=%s, authState=%d, connState=%d, tls=%s, elapsedMs=%lld, attempt=%s)\n",
-			ILibWebClient_GetDescriptorValue_FromStateObject(WebStateObject),
-			recvStatusStr, agent->serverAuthState, agent->serverConnectionState,
-			tlsState, elapsedMs, agent->connectAttemptId);
+		if (agent->controlChannelLogThisAttempt != 0)
+		{
+			long long elapsedMs = ILibGetUptime() - agent->controlChannelDialTick;
+			// tls is only meaningful for wss; the ConnectSink flag tracks plain TCP connect on ws.
+			const char *tlsState = (strncmp("wss:", agent->serveruri, 4) != 0) ? "n/a" : (agent->controlChannelTlsUp != 0 ? "up" : "down");
+			printf("Connection FAILED: No HTTP response (fd=%d, status=%s, authState=%d, connState=%d, tls=%s, elapsedMs=%lld, attempt=%s)\n",
+				ILibWebClient_GetDescriptorValue_FromStateObject(WebStateObject),
+				recvStatusStr, agent->serverAuthState, agent->serverConnectionState,
+				tlsState, elapsedMs, agent->connectAttemptId);
+		}
 
 		agent->autoproxy_status = 0;
 
@@ -4347,11 +4350,14 @@ void MeshServer_ConnectEx_NetworkError(void *j)
 	agent->controlChannelRequest = NULL;
 
 	if (agent->controlChannelDebug != 0) { printf("Network Timeout Occurred...\n"); }
-	long long elapsedMs = ILibGetUptime() - agent->controlChannelDialTick;
-	// tls is only meaningful for wss; the ConnectSink flag tracks plain TCP connect on ws.
-	const char *tlsState = (strncmp("wss:", agent->serveruri, 4) != 0) ? "n/a" : (agent->controlChannelTlsUp != 0 ? "up" : "down");
-	printf("Connection FAILED: Network timeout - server unreachable or gateway blocking (tls=%s, elapsedMs=%lld, attempt=%s)\n",
-		tlsState, elapsedMs, agent->connectAttemptId);
+	if (agent->controlChannelLogThisAttempt != 0)
+	{
+		long long elapsedMs = ILibGetUptime() - agent->controlChannelDialTick;
+		// tls is only meaningful for wss; the ConnectSink flag tracks plain TCP connect on ws.
+		const char *tlsState = (strncmp("wss:", agent->serveruri, 4) != 0) ? "n/a" : (agent->controlChannelTlsUp != 0 ? "up" : "down");
+		printf("Connection FAILED: Network timeout - server unreachable or gateway blocking (tls=%s, elapsedMs=%lld, attempt=%s)\n",
+			tlsState, elapsedMs, agent->connectAttemptId);
+	}
 	agent->serverConnectionState = 0;
 
 	ILibWebClient_CancelRequest(request);
@@ -4778,12 +4784,23 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 			}
 			else { proxylog = webproxy; }
 		}
-		printf("Connection: dialing uri=%s host=%s port=%u family=%s ip=%s useproxy=%d proxy=%s attempt=%s\n",
-			agent->serveruri, host, port,
-			(meshServer.sin6_family == AF_INET6 ? "IPv6" : (meshServer.sin6_family == AF_INET ? "IPv4" : "UNSPEC")),
-			(useproxy == 0 ? agent->serverip : "(via-proxy)"),
-			(int)useproxy,
-			proxylog, agent->connectAttemptId);
+		// Throttle repeated identical attempts: log the dial/failure pair only on target change or once per 60s, counting the rest.
+		char dialSig[160];
+		snprintf(dialSig, sizeof(dialSig), "%s|%s|%d", agent->serveruri, (useproxy == 0 ? agent->serverip : "proxy"), (int)useproxy);
+		agent->controlChannelLogThisAttempt = (agent->controlChannelLastLogTick == 0 || strcmp(dialSig, agent->controlChannelDialSig) != 0 || (agent->controlChannelDialTick - agent->controlChannelLastLogTick) >= 60000) ? 1 : 0;
+		if (agent->controlChannelLogThisAttempt != 0)
+		{
+			agent->controlChannelLastLogTick = agent->controlChannelDialTick;
+			strcpy_s(agent->controlChannelDialSig, sizeof(agent->controlChannelDialSig), dialSig);
+			printf("Connection: dialing uri=%s host=%s port=%u family=%s ip=%s useproxy=%d proxy=%s attempt=%s suppressed=%u\n",
+				agent->serveruri, host, port,
+				(meshServer.sin6_family == AF_INET6 ? "IPv6" : (meshServer.sin6_family == AF_INET ? "IPv4" : "UNSPEC")),
+				(useproxy == 0 ? agent->serverip : "(via-proxy)"),
+				(int)useproxy,
+				proxylog, agent->connectAttemptId, agent->controlChannelSuppressed);
+			agent->controlChannelSuppressed = 0;
+		}
+		else { agent->controlChannelSuppressed++; }
 
 		ILibWebClient_AddWebSocketRequestHeaders(req, 65535, MeshServer_OnSendOK);
 

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4304,9 +4304,11 @@ void MeshServer_OnResponse(ILibWebClient_StateObject WebStateObject, int Interru
 		}
 		ILibRemoteLogging_printf(ILibChainGetLogger(ILibWebClient_GetChainFromWebStateObject(WebStateObject)), ILibRemoteLogging_Modules_Agent_GuardPost, ILibRemoteLogging_Flags_VerbosityLevel_1, "Agent Host Container: Mesh Server Connection Error, trying again later.");
 
-		printf("Connection FAILED: No HTTP response (fd=%d, status=%s, authState=%d, connState=%d)\n",
+		long long elapsedMs = ILibGetUptime() - agent->controlChannelDialTick;
+		printf("Connection FAILED: No HTTP response (fd=%d, status=%s, authState=%d, connState=%d, tls=%s, elapsedMs=%lld, attempt=%s)\n",
 			ILibWebClient_GetDescriptorValue_FromStateObject(WebStateObject),
-			recvStatusStr, agent->serverAuthState, agent->serverConnectionState);
+			recvStatusStr, agent->serverAuthState, agent->serverConnectionState,
+			(agent->controlChannelTlsUp != 0 ? "up" : "down"), elapsedMs, agent->connectAttemptId);
 
 		agent->autoproxy_status = 0;
 
@@ -4343,7 +4345,9 @@ void MeshServer_ConnectEx_NetworkError(void *j)
 	agent->controlChannelRequest = NULL;
 
 	if (agent->controlChannelDebug != 0) { printf("Network Timeout Occurred...\n"); }
-	printf("Connection FAILED: Network timeout - server unreachable or gateway blocking\n");
+	long long elapsedMs = ILibGetUptime() - agent->controlChannelDialTick;
+	printf("Connection FAILED: Network timeout - server unreachable or gateway blocking (tls=%s, elapsedMs=%lld, attempt=%s)\n",
+		(agent->controlChannelTlsUp != 0 ? "up" : "down"), elapsedMs, agent->connectAttemptId);
 	agent->serverConnectionState = 0;
 
 	ILibWebClient_CancelRequest(request);
@@ -4389,6 +4393,14 @@ duk_ret_t MeshServer_ConnectEx_AutoProxy(duk_context *ctx)
 
 	MeshServer_ConnectEx(agent);
 	return(0);
+}
+
+void MeshServer_ControlChannel_ConnectSink(ILibWebClient_RequestToken sender)
+{
+	// Fires after TCP connect + TLS handshake, before the HTTP upgrade is sent.
+	void **uo = ILibWebClient_RequestToken_GetUserObjects(sender);
+	MeshAgentHostContainer *agent = (uo != NULL) ? (MeshAgentHostContainer*)uo[0] : NULL;
+	if (agent != NULL) { agent->controlChannelTlsUp = 1; }
 }
 
 void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
@@ -4737,6 +4749,15 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 	{
 		if (useproxy == 0) { strcpy_s(agent->serverip, sizeof(agent->serverip), ILibRemoteLogging_ConvertAddress((struct sockaddr*)&meshServer)); }
 
+		// Per-attempt diag state: reset TLS-reached flag, stamp dial time, and mint a correlation id matchable in gateway/server logs.
+		unsigned int attemptRand;
+		util_random(sizeof(attemptRand), (char*)&attemptRand);
+		agent->connectAttemptSeq++;
+		agent->controlChannelTlsUp = 0;
+		agent->controlChannelDialTick = ILibGetUptime();
+		sprintf_s(agent->connectAttemptId, sizeof(agent->connectAttemptId), "%08X-%u", attemptRand, agent->connectAttemptSeq);
+		ILibAddHeaderLine(req, "X-Agent-Attempt", 15, agent->connectAttemptId, (int)strnlen_s(agent->connectAttemptId, sizeof(agent->connectAttemptId)));
+
 		// Diag: log where each control-channel attempt dials (IP/family/proxy) so a failed attempt is self-describing; these die before any server-side log.
 		// Redact user:pass@ credentials from the proxy URI before logging (keep scheme://host:port).
 		char proxyredacted[1024];
@@ -4753,12 +4774,12 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 			}
 			else { proxylog = webproxy; }
 		}
-		printf("Connection: dialing uri=%s host=%s port=%u family=%s ip=%s useproxy=%d proxy=%s\n",
+		printf("Connection: dialing uri=%s host=%s port=%u family=%s ip=%s useproxy=%d proxy=%s attempt=%s\n",
 			agent->serveruri, host, port,
 			(meshServer.sin6_family == AF_INET6 ? "IPv6" : (meshServer.sin6_family == AF_INET ? "IPv4" : "UNSPEC")),
 			(useproxy == 0 ? agent->serverip : "(via-proxy)"),
 			(int)useproxy,
-			proxylog);
+			proxylog, agent->connectAttemptId);
 
 		ILibWebClient_AddWebSocketRequestHeaders(req, 65535, MeshServer_OnSendOK);
 
@@ -4766,6 +4787,7 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 		agent->controlChannelRequest = tmp;
 		tmp[0] = agent;
 		tmp[1] = reqToken = ILibWebClient_PipelineRequest(agent->httpClientManager, (struct sockaddr*)&meshServer, req, MeshServer_OnResponse, agent, NULL);
+		ILibWebClient_RequestToken_ConnectionHandler_Set(reqToken, MeshServer_ControlChannel_ConnectSink, NULL);
 		ILibLifeTime_Add(ILibGetBaseTimer(agent->chain), tmp, 20, MeshServer_ConnectEx_NetworkError, MeshServer_ConnectEx_NetworkError_Cleanup);
 
 #ifndef MICROSTACK_NOTLS

--- a/meshcore/agentcore.h
+++ b/meshcore/agentcore.h
@@ -198,6 +198,10 @@ typedef struct MeshAgentHostContainer
 	int controlChannelTlsUp;
 	unsigned int connectAttemptSeq;
 	char connectAttemptId[24];
+	char controlChannelDialSig[160];
+	long long controlChannelLastLogTick;
+	unsigned int controlChannelSuppressed;
+	int controlChannelLogThisAttempt;
 
 #ifdef WIN32
 	void *shCore;

--- a/meshcore/agentcore.h
+++ b/meshcore/agentcore.h
@@ -194,6 +194,10 @@ typedef struct MeshAgentHostContainer
 	struct sockaddr_in6* proxyServer;
 	int proxyFailed;
 	void *controlChannelRequest;
+	long long controlChannelDialTick;
+	int controlChannelTlsUp;
+	unsigned int connectAttemptSeq;
+	char connectAttemptId[24];
 
 #ifdef WIN32
 	void *shCore;


### PR DESCRIPTION
## Why

On some machines the agent spews repeated `Connection FAILED: No HTTP response` and `Connection FAILED: Network timeout` messages. Both failures happen **before** MeshCentral / the gateway ever accept the WebSocket upgrade, so there is no server-side record of them — the agent log is the only evidence, and today it doesn't say *where in the connect the attempt died*.

This is the Step-1 agent-side instrumentation from the offline-agent investigation (follow-up to #56, which added the `Connection: dialing ...` line).

## What

Adds three signals to the two failure log lines (and a correlation header), all in the control-channel path in `agentcore.c`:

- **`tls=up|down`** — set via a new `ConnectSink` registered on the request token, which fires after TCP connect + TLS handshake but before the HTTP upgrade is sent.
  - `down` ⇒ the attempt died during TCP connect or the TLS handshake (pair with the existing `TLS Handshake FAILED/ERROR` lines to tell which).
  - `up` ⇒ TLS was fine; the server/gateway closed **after** TLS but before the `101` — i.e. application-layer.
- **`elapsedMs`** — time since the dial, separating an immediate RST from a slow death or the full 20 s network-timeout. (Monotonic via `ILibGetUptime()`; ~second-resolution on Linux due to a pre-existing quirk, full ms on macOS/Windows.)
- **`attempt=<rand>-<seq>`** — a per-attempt id, **also sent as the `X-Agent-Attempt` request header**, so one agent failure can be matched to a gateway connection record and a MeshCentral record. This is the key to correlating the three logs.

### Example

```
Connection: dialing uri=wss://srv:443/agent.ashx host=srv port=443 family=IPv6 ip=(via-proxy) useproxy=0 proxy=DIRECT attempt=1A2B3C4D-7
Connection FAILED: No HTTP response (fd=12, status=Complete/Disconnected, authState=0, connState=0, tls=down, elapsedMs=83, attempt=1A2B3C4D-7)
```
→ IPv6, direct, TLS never came up, died in 83 ms ⇒ unreachable/blackholed IPv6 target.

## Risk / scope

- Log-only + 4 new struct fields; no behavior change to the connection logic.
- Uses public microstack APIs (`ConnectionHandler_Set`, `RequestToken_GetUserObjects`); no microstack edits.
- Syntax-checked locally with the macOS/POSIX build defines — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection failure logging for control-channel setup, including richer details when a handshake gets no response or a network timeout occurs.
  * Added clearer attempt tracking so repeated connection tries can be correlated more easily in logs.
  * Expanded connection diagnostics to show whether a connection used a proxy or direct path, plus additional timing and network context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->