### PR TITLE
fix: single-flight guard in MeshServer_ConnectEx (prevent duplicate agent connections)

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4437,7 +4437,10 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 	}
 
 	// If this is called while we are in any connection state, just leave now.
-
+	if (agent->serverConnectionState != 0         // established (=2) or connecting (=1) - same core as MeshServer_Connect
+		|| agent->controlChannel != NULL          // covers the pong-timeout window (controlChannel NULLed before state clears)
+		|| agent->controlChannelRequest != NULL)  // covers the in-flight-request window before state is set to 1
+	{ return; }
 
 	len = ILibSimpleDataStore_Get(agent->masterDb, "MeshServer", ILibScratchPad2, sizeof(ILibScratchPad2));
 


### PR DESCRIPTION
## Problem
`MeshServer_ConnectEx` is the choke point that actually opens the control-channel socket, but it has **no re-entry guard**. The guard only lives in `MeshServer_Connect` (`if (serverConnectionState != 0) return;`). Several paths reach `ConnectEx` **directly, bypassing that guard**:
- `MeshServer_ConnectEx_NetworkError` (the 20s connect-timeout retry)
- `MeshServer_ConnectEx_Lockout_Retry`
- `MeshServer_ConnectEx_AutoProxy`
- **`Connect`'s own backoff timer** — `ILibLifeTime_AddEx(…, MeshServer_ConnectEx, …)` fires the delayed connect directly, so even the guarded `Connect` path ends up bypassing the guard when the timer fires.

Result: a straggler retry timer can open a **second** connection while one is already established. MeshCentral then evicts the duplicate (`completeAgentConnection3` → `dupAgent.close(3)`), which is the source of the recurring **`Agent WS closed from undefined (authenticated=-1, nodeid=none, …)`** orphan closes we traced (the `close(3)` abandons the socket without disconnecting, so it lingers ~150s and logs the wiped state on final close).

This is a **latent upstream weakness** (guard-in-`Connect`-only since the 2017 first commit; the direct `NetworkError → ConnectEx` call is upstream, 2020), not a fork regression — but our environment (hourly JWT force-close + token churn + the site NAT) hammers those paths, so it shows up constantly.

## Fix
Add the guard where the existing comment already says it belongs — the top of `MeshServer_ConnectEx` — as a **superset** of `Connect`'s condition:
```c
if (agent->serverConnectionState != 0         // established (=2) or connecting (=1) - same core as MeshServer_Connect
    || agent->controlChannel != NULL          // covers the pong-timeout window (controlChannel NULLed before state clears)
    || agent->controlChannelRequest != NULL)  // covers the in-flight-request window before state is set to 1
{ return; }
```
`Connect` is left untouched (it keeps short-circuiting the backoff scheduling); `ConnectEx` is now the real backstop that covers every path, including the timer callback and the AutoProxy continuation.

## Why it's safe (no deadlock)
- The guard sits **before** the async autoproxy early-return, so the AutoProxy re-entry still passes (no request/connection exists yet during proxy detection).
- If the live connection dies silently (half-open), the built-in keepalive clears the state: idle-timeout (120s) → WS ping → 5s pong-timeout → `..._PongTimeout` disconnects and NULLs `controlChannel`; `OnResponse` then sets `serverConnectionState = 0`. So a stale "connected" state self-clears within **~125s** and the guard un-blocks. This is the same bound the existing `MeshServer_Connect` guard already relies on — not a new failure mode. In-flight attempts are bounded to ~20s by the existing `NetworkError` timer.

## Notes
- Diagnostic-adjacent but this is a **behavior change**, kept separate from the diag PRs (#56 etc.).
- Not compiled locally (no local toolchain for the agent build) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate control-channel connection attempts when a connection is already active, a control channel exists, or a prior connection request is still pending.
  * Improved connection stability during reconnect and timeout scenarios by avoiding overlapping requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->