### PR TITLE
fix: make Openframe token diag line parseable by openframe-client

### DIFF
--- a/openframe/token_extractor.c
+++ b/openframe/token_extractor.c
@@ -66,7 +66,7 @@ char* extract_token(const char* secret, const char* token_path) {
         gmtime_r(&now, &tmv);
 #endif
         strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tmv);
-        printf("Openframe token: read JWT from %s at %s: %s\n", filename, ts, decrypted_token);
+        printf("%s INFO Openframe token: read JWT from %s: %s tool_id=meshcentral-agent\n", ts, filename, decrypted_token);
     }
 
     return decrypted_token;


### PR DESCRIPTION
## What

The token-read diagnostic in `openframe/token_extractor.c` printed:

```
Openframe token: read JWT from <path> at <ts>: <jwt>
```

Because that line does **not** start with an RFC3339 timestamp, it was silently dropped by openframe-client's log ingest. The client's `parse_log_line` / `parse_tracing_format` only ships lines shaped as `<rfc3339-ts> LEVEL <msg>` (or logrus `time="..."`), so this diagnostic never reached the central logs — it only ever appeared raw in the local `meshcentral-agent.log`.

## Change

Reorder the line to lead with the UTC timestamp and append the `tool_id=meshcentral-agent` field, matching the tracing format the agent already emits (and that the client parses):

```
<ts> INFO Openframe token: read JWT from <path>: <jwt> tool_id=meshcentral-agent
```

- One-line change to the `printf` format string in `token_extractor.c`.
- The `at <ts>` in the message body is dropped as redundant (timestamp is now the leading prefix).
- Token value is intentionally left **visible** for now, per current diagnostic needs.

## Note

This line logs the full decrypted JWT in plaintext, which will now be shipped to central logs (the sibling `Openframe JWT:` line in `agentcore.c` already is). This is acceptable for the current investigation but should be redacted (log length / prefix / `iat`/`exp` claims instead of the token body) once diagnostics are complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic output when reading and decrypting a token, making it easier to identify the source and status of the event.
  * Added clearer context to token-related messages to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->