### PR TITLE
fix: evict stale pooled connection before each control-channel dial

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4807,6 +4807,9 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 
 		ILibWebClient_AddWebSocketRequestHeaders(req, 65535, MeshServer_OnSendOK);
 
+		// Evict any stale pooled connection to this address so every dial performs a fresh TCP+TLS connect instead of riding a dead kept-alive socket.
+		ILibWebClient_DeleteRequests(agent->httpClientManager, (struct sockaddr*)&meshServer);
+
 		void **tmp = ILibMemory_SmartAllocate(2 * sizeof(void*));
 		agent->controlChannelRequest = tmp;
 		tmp[0] = agent;


### PR DESCRIPTION
## Problem

During the mikart mesh-offline incident (Jul 1-2), agents entered a permanent retry loop logging `Connection FAILED: No HTTP response (… tls=down, elapsedMs=0 …)` every 4-6 minutes for 12+ hours, while `/ws/nats` connections from the same machines to the same IP/LB kept working. Evidence that the failure is local to the meshagent process:

- `elapsedMs=0`: hundreds of consecutive attempts failed in the same millisecond as the dial — impossible for any network exchange.
- The gateway's first request filter (logs every arriving upgrade) recorded almost none of the thousands of client-side attempts — the dials never left the machine.
- A TCP/TLS failure cannot be selective by URL path; NATS WS to the same address worked throughout.
- Every observed recovery coincided exactly with a meshagent process start (`attempt=…-1`); the one machine that never restarted (attempt counter 1→2533) never recovered.

## Mechanism

`ILibWebClient_PipelineRequestEx2` reuses a kept-alive connection from the manager's `DataTable` when an entry exists for the target address (`microstack/ILibWebClient.c` "Previous connection exists!" path). If that pooled socket was abortively closed by the gateway (SO_LINGER=0 RST) or died during a network blip, the queued upgrade fails immediately with no HTTP bytes — `MeshServer_ControlChannel_ConnectSink` never fires (hence `tls=down`), and each retry re-queues onto the same dead object.

## Fix

Call `ILibWebClient_DeleteRequests(agent->httpClientManager, &meshServer)` immediately before pipelining the upgrade in `MeshServer_ConnectEx`, evicting any pooled connection for the target address so every dial performs a fresh TCP+TLS connect. Connection reuse buys nothing here: the control channel is one long-lived WebSocket, dialed at most once per hour when healthy.

## Safety

- The single-flight guard (#58) guarantees `serverConnectionState == 0 && controlChannel == NULL && controlChannelRequest == NULL` at this point, so there are no pending requests to abort — the call can only disconnect an idle stale socket.
- `agent->httpClientManager` has exactly one pipeline call site (the control-channel dial), so no other subsystem shares these pooled connections.
- `ILibAsyncSocket_Disconnect` synchronously invalidates the socket (`internalSocket = ~0`), so the subsequent `PipelineRequest` takes the reconnect path (`SOCK == NULL || IsFree`) rather than racing the teardown.
- Works for the proxy path too: the pool key is always `meshServer` (the address passed to `PipelineRequest`); proxy config is applied to the request token afterwards.

## Testing

- CI PR build compiles all targets.
- Suggested manual repro: establish control channel, RST the connection mid-session (or drop DNS briefly), confirm the next dial performs a full TCP+TLS handshake (`tls=up` or success) instead of the instant `elapsedMs=0` failure loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability by ensuring new connection attempts start with a fresh network session instead of reusing stale cached requests.
  * Reduced failures caused by dead keep-alive connections when reconnecting to a server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->