### PR TITLE
Disable agent service auto-restart (keep auto-start); log decorated startup version marker

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -5479,6 +5479,8 @@ int MeshAgent_AgentMode(MeshAgentHostContainer *agentHost, int paramLen, char **
 		{
 			agentHost->openFrameMode = true; parseCommands = 0;
 			enable_file_logging_simple();
+			// Decorated startup marker parsed by openframe-client
+			openframe_printf("MeshAgent starting (build %s, self-update version %d)\n", SOURCE_COMMIT_DATE, MESH_AGENT_VERSION);
 		}
 		if (strcmp(param[ri], "--openframe-secret") == 0 && ((ri + 1) < paramLen))
 		{

--- a/modules/agent-installer.js
+++ b/modules/agent-installer.js
@@ -1146,6 +1146,7 @@ function createLaunchDaemon(serviceName, companyName, installPath, serviceId, in
             name: serviceName,
             target: 'meshagent',
             startType: 'AUTO_START',
+            failureRestart: 0, // auto-start on boot, but do not restart on crash/exit
             parameters: ['--serviceId', serviceId],
             companyName: companyName
         };
@@ -1910,6 +1911,7 @@ function installService(params)
             target: target==null?(process.platform == 'win32' ? 'MeshAgent' : 'meshagent'):target,
             servicePath: process.execPath,
             startType: 'AUTO_START',
+            failureRestart: 0, // auto-start on boot, but do not restart on crash/exit
             parameters: params,
             _installer: true
         };

--- a/modules/service-manager.js
+++ b/modules/service-manager.js
@@ -2977,6 +2977,7 @@ function serviceManager()
             var stdoutpath = (options.stdout ? ('<key>StandardOutPath</key>\n<string>' + options.stdout + '</string>') : ('<key>StandardOutPath</key>\n<string>/tmp/' + serviceId + '-daemon.log</string>'));
             var stderrpath = (options.stderr ? ('<key>StandardErrorPath</key>\n<string>' + options.stderr + '</string>') : ('<key>StandardErrorPath</key>\n<string>/tmp/' + serviceId + '-daemon.log</string>'));
             var autoStart = (options.startType == 'AUTO_START' ? '<true/>' : '<false/>');
+            var keepAlive = ((options.failureRestart == null || options.failureRestart > 0) ? '<true/>' : '<false/>'); // launchd restart-on-exit
 
             // Apply OpenFrame parameters formatting for macOS
             console.log('[DEBUG service-manager] options.parameters before processing: ' + JSON.stringify(options.parameters));
@@ -3002,7 +3003,7 @@ function serviceManager()
             plist += '      <key>Disabled</key>\n';
             plist += '      <false/>\n';
             plist += '      <key>KeepAlive</key>\n';
-            plist += '      <true/>\n';
+            plist += ('      ' + keepAlive + '\n');
             plist += '      <key>Label</key>\n';
             plist += ('     <string>' + serviceId + '</string>\n');
             plist += (params + '\n');


### PR DESCRIPTION
## Description
Two independent changes to the OpenFrame MeshAgent:

1. **Disable the installed agent service's auto-restart-on-crash, while keeping auto-start-on-boot.** Previously the agent daemon was configured to respawn after any crash/exit on every platform (Windows SCM recovery actions, systemd `Restart=on-failure`, launchd `KeepAlive`, upstart/procd/OpenRC `respawn`). It now starts on boot but is **not** restarted if it exits or crashes.

2. **Log a decorated startup marker with the version on agent startup**, so the line is parseable by `openframe-client`.

## Improvements
- Pass `failureRestart: 0` in both daemon install option-builders in `modules/agent-installer.js` (macOS LaunchDaemon + Windows/Linux). The existing gating `failureRestart == null || failureRestart > 0` already honors this on all ~8 platform paths (Windows FailureActions, systemd, upstart, procd, OpenRC, SysV, BSD rc, pseudo-daemon).
- Make the macOS LaunchDaemon `KeepAlive` key honor `failureRestart` in `modules/service-manager.js` (it was hard-coded `<true/>`), matching every other platform.
- Auto-start-on-boot is untouched: Windows start type `0x02`, systemd `WantedBy=multi-user.target` + `systemctl enable`, and macOS `RunAtLoad` all remain.
- Emit a decorated startup line in `meshcore/agentcore.c` (in `MeshAgent_AgentMode`, right after openframe file logging is enabled) via `openframe_printf`, printing both version markers found in the tree — the build/commit date (`SOURCE_COMMIT_DATE`, same string used in the HTTP User-Agent) and the integer self-update version (`MESH_AGENT_VERSION`):
  ```
  <ts> INFO MeshAgent starting (build <SOURCE_COMMIT_DATE>, self-update version <MESH_AGENT_VERSION>) tool_id=meshcentral-agent
  ```

### Scope note
"Auto-restart disabled" is scoped to **the agent daemon** — the only persistent service a normal agent install creates. Two other `installService` call sites are intentionally left as-is: the transient macOS message-box helper (a throwaway LaunchAgent that already uses `KeepAlive false`) and `meshcmd`'s own `MicroLMS`/`MeshCommander` service (a separate CLI tool, only installed via an explicit `meshcmd ... install`).

> ⚠️ **Behavioral implication:** disabling restart-on-exit also affects self-update, which relies on the agent exiting and the service manager relaunching the new binary (launchd `KeepAlive`, systemd `Restart=`). With restart off, an agent that exits to self-update — or simply crashes — will stay down until the next reboot.

## Task
_No linked ticket._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an OpenFrame-compatible startup marker when OpenFrame mode is enabled, including build and version details for client parsing.

* **Bug Fixes**
  * Updated service installation behavior so auto-start services no longer restart automatically after a crash or exit, with consistent behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->