### PR TITLE
Add exponential backoff on all mesh agent control-channel retry paths

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -92,6 +92,8 @@ int gRemoteMouseRenderDefault = 0;
 #define SCRIPT_ENGINE_PIPE_BUFFER_SIZE 65535
 #define SERVER_DISCOVERY_BUFFER_SIZE 1024
 #define CONTROL_CHANNEL_LOG_THROTTLE_MS 600000	 //!< Steady-state control-channel dial/failure logging throttle (10 min); target changes still log immediately
+#define MESH_BACKOFF_STABLE_SESSION_MS 60000	 //!< An authenticated session must live this long before its drop resets the reconnect backoff
+#define MESH_BACKOFF_MIN_RETRY_MS 2000			 //!< Floor for the halved backoff after a short-lived authenticated session
 
 #define MESH_AGENT_PORT 16990					 //!< Default Mesh Agent Port
 #define MESH_MCASTv4_GROUP "239.255.255.235"
@@ -3020,6 +3022,7 @@ void MeshServer_ServerAuthenticated(ILibWebClient_StateObject WebStateObject, Me
 	if (agent->serverAuthState == 3)
 	{
 		printf("Server fully authenticated (authState=3)\n");
+		agent->authTick = ILibGetUptime();
 		ILibDuktape_MeshAgent_PUSH(agent->meshCoreCtx, agent->chain);				// [agent]
 		duk_get_prop_string(agent->meshCoreCtx, -1, "emit");						// [agent][emit]
 		duk_swap_top(agent->meshCoreCtx, -2);										// [emit][this]
@@ -3101,7 +3104,6 @@ void MeshServer_SendAgentInfo(MeshAgentHostContainer* agent, ILibWebClient_State
 
 	// Send mesh agent information to the server
 	ILibWebClient_WebSocket_Send(WebStateObject, ILibWebClient_WebSocket_DataType_BINARY, (char*)info, sizeof(MeshCommand_BinaryPacket_AuthInfo) + hostnamelen, ILibAsyncSocket_MemoryOwnership_USER, ILibWebClient_WebSocket_FragmentFlag_Complete);
-	agent->retryTime = 0;
 
 	if ((agent->capabilities & MeshCommand_AuthInfo_CapabilitiesMask_RECOVERY) == MeshCommand_AuthInfo_CapabilitiesMask_RECOVERY)
 	{
@@ -4128,6 +4130,9 @@ void MeshServer_OnResponse(ILibWebClient_StateObject WebStateObject, int Interru
 			}
 
 			agent->controlChannel = WebStateObject; // Set the agent MeshCentral server control channel
+			// A live connection makes any pending retry/lockout timer stale; drop it so a later disconnect schedules against fresh backoff state.
+			ILibLifeTime_Remove(ILibGetBaseTimer(agent->chain), agent);
+			agent->retryTimerPending = 0;
 			printf("Control channel established [fd=%d]\n", ILibWebClient_GetDescriptorValue_FromStateObject(WebStateObject));
 			printf("Connection: WebSocket upgrade successful (fd=%d), starting handshake authentication\n", ILibWebClient_GetDescriptorValue_FromStateObject(WebStateObject));
 			ILibRemoteLogging_printf(ILibChainGetLogger(agent->chain), ILibRemoteLogging_Modules_Agent_GuardPost | ILibRemoteLogging_Modules_ConsolePrint, ILibRemoteLogging_Flags_VerbosityLevel_1, "Control Channel Idle Timeout = %d seconds", agent->controlChannel_idleTimeout_seconds);
@@ -4223,6 +4228,10 @@ void MeshServer_OnResponse(ILibWebClient_StateObject WebStateObject, int Interru
 				// Post-auth drop is a rare, meaningful state change (a healthy session closing) - always log it.
 				printf("Connection LOST: Disconnected after authentication (fd=%d) - server closed connection\n",
 					ILibWebClient_GetDescriptorValue_FromStateObject(WebStateObject));
+				// Only a session that stayed authenticated for a while proves the server healthy enough to reset backoff; a short-lived one just halves it.
+				if (agent->authTick != 0 && (ILibGetUptime() - agent->authTick) >= MESH_BACKOFF_STABLE_SESSION_MS) { agent->retryTime = 0; }
+				else if (agent->retryTime > 2 * MESH_BACKOFF_MIN_RETRY_MS) { agent->retryTime /= 2; }
+				agent->authTick = 0;
 			}
 			if (agent->controlChannelDebug != 0)
 			{
@@ -4368,7 +4377,8 @@ void MeshServer_ConnectEx_NetworkError(void *j)
 	agent->serverConnectionState = 0;
 
 	ILibWebClient_CancelRequest(request);
-	MeshServer_ConnectEx(agent);
+	// CancelRequest normally fired OnResponse->MeshServer_Connect synchronously; this fallback coalesces to a no-op but guarantees forward progress.
+	MeshServer_Connect(agent);
 }
 void MeshServer_ConnectEx_NetworkError_Cleanup(void *j)
 {
@@ -4437,6 +4447,8 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 
 
 	memset(&meshServer, 0, sizeof(struct sockaddr_in6));
+	// Must clear before the re-entry guard, or a guard-blocked stale timer would strand the flag and block all future retry scheduling.
+	agent->retryTimerPending = 0;
 	if (agent->timerLogging != 0 && agent->retryTimerSet != 0)
 	{
 		agent->retryTimerSet = 0;
@@ -5010,10 +5022,12 @@ void MeshServer_Connect(MeshAgentHostContainer *agent)
 	else
 	{
 		int delay;
-		if (agent->retryTime >= 240000)
+		// A retry timer is already scheduled (e.g. by the cancel-induced OnResponse); coalesce instead of double-scheduling.
+		if (agent->retryTimerPending != 0) { return; }
+		if (agent->retryTime >= 480000)
 		{
-			// Cap at around 4 minutes
-			delay = 240000 + (timeout % 120000);					// Random value between 4 and 6 minutes
+			// Cap at around 8 minutes
+			delay = 480000 + (timeout % 120000);					// Random value between 8 and 10 minutes
 		}
 		else
 		{
@@ -5022,6 +5036,7 @@ void MeshServer_Connect(MeshAgentHostContainer *agent)
 		// Throttle the offline-retry-loop spam: only log the retry schedule on cycles the throttle decided to log.
 		if (agent->controlChannelLogThisAttempt != 0) { printf("AutoRetry Connect in %d milliseconds\n", delay); }
 		if (agent->timerLogging != 0) { agent->retryTimerSet = 1; }
+		agent->retryTimerPending = 1;
 		ILibLifeTime_AddEx(ILibGetBaseTimer(agent->chain), agent, delay, (ILibLifeTime_OnCallback)MeshServer_ConnectEx, NULL);
 		agent->retryTime = delay;
 	}

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4228,9 +4228,9 @@ void MeshServer_OnResponse(ILibWebClient_StateObject WebStateObject, int Interru
 				// Post-auth drop is a rare, meaningful state change (a healthy session closing) - always log it.
 				printf("Connection LOST: Disconnected after authentication (fd=%d) - server closed connection\n",
 					ILibWebClient_GetDescriptorValue_FromStateObject(WebStateObject));
-				// Only a session that stayed authenticated for a while proves the server healthy enough to reset backoff; a short-lived one just halves it.
+				// Only a session that stayed authenticated for a while proves the server healthy enough to reset backoff; a short-lived one halves it, never below the floor.
 				if (agent->authTick != 0 && (ILibGetUptime() - agent->authTick) >= MESH_BACKOFF_STABLE_SESSION_MS) { agent->retryTime = 0; }
-				else if (agent->retryTime > 2 * MESH_BACKOFF_MIN_RETRY_MS) { agent->retryTime /= 2; }
+				else { agent->retryTime = (agent->retryTime > 2 * MESH_BACKOFF_MIN_RETRY_MS) ? (agent->retryTime / 2) : MESH_BACKOFF_MIN_RETRY_MS; }
 				agent->authTick = 0;
 			}
 			if (agent->controlChannelDebug != 0)
@@ -5032,6 +5032,7 @@ void MeshServer_Connect(MeshAgentHostContainer *agent)
 		else
 		{
 			delay = agent->retryTime + (timeout % agent->retryTime);		// Random value between current value and double the current value
+			if (delay >= 480000) { delay = 480000 + (timeout % 120000); }	// Never let the last doubling overshoot the 8-10 minute cap
 		}
 		// Throttle the offline-retry-loop spam: only log the retry schedule on cycles the throttle decided to log.
 		if (agent->controlChannelLogThisAttempt != 0) { printf("AutoRetry Connect in %d milliseconds\n", delay); }

--- a/meshcore/agentcore.h
+++ b/meshcore/agentcore.h
@@ -253,7 +253,9 @@ typedef struct MeshAgentHostContainer
 	int serverAuthState;
 
 	int timerLogging;
-	int retryTimerSet;
+	int retryTimerSet;			// timerLogging diagnostic only
+	int retryTimerPending;		// a scheduled ConnectEx retry timer is pending; coalesces MeshServer_Connect calls
+	long long authTick;			// uptime (ms) when full server auth completed; 0 when not authenticated
 	int controlChannel_idleTimeout_seconds;
 	int controlChannel_idleTimeout_dataMode;
 	char g_selfid[UTIL_SHA384_HASHSIZE];


### PR DESCRIPTION
## Summary

Implements [86ajmt7ty](https://app.clickup.com/t/9013925967/86ajmt7ty): the mesh agent must back off exponentially on all server-communication retry paths and never flood the server with rapid retries.

The existing backoff in `MeshServer_Connect` (jittered doubling) already covered pre-upgrade failures (DNS, TCP, TLS, non-101 responses), but two paths defeated it:

1. **Zero-delay reconnect flood**: `MeshServer_SendAgentInfo` reset `retryTime = 0` mid-handshake, before the server confirmed agent auth. A server that completes the WebSocket upgrade but errors/closes before `AuthConfirm` caused an immediate-reconnect loop bounded only by TCP+TLS handshake speed.
2. **Dial-timeout bypass**: the 20s dial timeout re-dialed via `MeshServer_ConnectEx` directly, overriding the backoff delay its own cancel path had just scheduled — a fixed 20s loop against a hung/blackholed server.

## Changes

- Reset backoff only after an authenticated session survives 60s (`MESH_BACKOFF_STABLE_SESSION_MS`); shorter post-auth sessions halve `retryTime` (floor ~2s) so a flapping-but-working server still recovers quickly while an auth-then-die crash loop stays paced. `authTick` is stamped in `MeshServer_ServerAuthenticated` (single choke point covering both auth-completion orders).
- `MeshServer_ConnectEx_NetworkError` now falls back to `MeshServer_Connect`; a new `retryTimerPending` flag coalesces scheduling so each failure cycle grows the delay exactly once. The flag is cleared at the top of `MeshServer_ConnectEx` before the re-entry guard (ordering is load-bearing: a guard-blocked stale timer must not strand the flag) and on connection establishment.
- Connection establishment drops stale agent-keyed retry/lockout timers (`ILibLifeTime_AddEx` dedupes by key, so duplicate timers are structurally impossible).
- Backoff cap raised from 4–6 min to jittered 8–10 min.

## Verification

- macOS ARM64 debug build clean; no new `-Wall` warnings (verified via syntax-only compile of the committed file).
- Two independent adversarial reviews (design + implementation): flag/timer state machine verified strand-proof across all call sites and interleavings on the chain thread; `ILibWebClient_CancelRequest` confirmed to synchronously fire `OnResponse(header=NULL)` on the chain thread, making the NetworkError fallback a coalesced no-op in the normal case; no watchdog depends on the previous ~6 min cap (service auto-restart disabled in 7f2ad09).

Known-accepted (out of scope): IP-change handler still resets backoff to 3s (event-driven, bounded); pre-existing dormancy on ServerID/MeshID config errors; multi-server failover now waits the backoff delay instead of 20s (single-URL configs unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect behavior after temporary network interruptions.
  * Prevented duplicate retry scheduling and cleared stale retry state when connections are restored.
  * Added stability-aware backoff handling so brief sessions recover more gradually while longer authenticated sessions reset normally.
  * Increased the maximum retry delay window to reduce repeated rapid connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->