### PR TITLE
ci: add Trivy security scan to PR pipeline

### DIFF
--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -1,11 +1,23 @@
 name: "Trivy"
-description: "PR security gate: scans repository dependencies (fs) and Dockerfile base images, prints findings and fails on HIGH/CRITICAL with a fix available"
+description: "Trivy PR security scans. scan: code = repo dependencies (HIGH/CRITICAL) + Dockerfile base images (CRITICAL), image = image built in the pipeline (HIGH/CRITICAL). Each scan uploads its TSV report as an artifact"
 
 inputs:
+  scan:
+    description: "code | image"
+    required: true
   maven-token:
-    description: "Token Maven uses to read internal artifacts from GitHub Packages (defaults to the workflow token, which cannot read other repos' packages)"
+    description: "Token for internal GitHub Packages: Maven resolution (scan: code) and docker build secret (scan: image)"
     required: false
     default: ${{ github.token }}
+  image-name:
+    description: "Service name from the build matrix (scan: image)"
+    required: false
+  dockerfile:
+    description: "Path to the service Dockerfile (scan: image)"
+    required: false
+  context:
+    description: "Docker build context (scan: image)"
+    required: false
 
 runs:
   using: composite
@@ -16,75 +28,86 @@ runs:
         version: v0.73.0
         cache: true
 
-    - name: Scan and evaluate
+    - name: Scan dependencies and Dockerfile base images
+      if: inputs.scan == 'code'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.maven-token }}
         GITHUB_ACTOR: ${{ github.actor }}
       run: |
         set -euo pipefail
-
-        # --- maven: resolve deps into ~/.m2 via Google's Central mirror so trivy
-        #     can analyze parent-managed versions fully offline (no rate limits) ---
-        if [ -f pom.xml ]; then
-          printf '%s\n' \
-            '<settings><mirrors><mirror>' \
-            '  <id>google-central</id>' \
-            '  <name>Google mirror of Maven Central</name>' \
-            '  <url>https://maven-central.storage-download.googleapis.com/maven2/</url>' \
-            '  <mirrorOf>central</mirrorOf>' \
-            '</mirror></mirrors></settings>' > /tmp/central-mirror.xml
-          margs=(-B -q -fn -DskipTests -gs /tmp/central-mirror.xml dependency:go-offline)
-          [ -f .mvn/settings.xml ] && margs+=(-s .mvn/settings.xml)
-          mvn "${margs[@]}" | tee /tmp/mvn.log || true
-          if grep -q '\[ERROR\]' /tmp/mvn.log; then
-            echo "::warning::Some Maven dependencies could not be resolved; pom.xml scan depth may be reduced"
-          fi
+        if [ -f pom.xml ]; then  # warm ~/.m2 via Google's Central mirror so trivy sees parent-managed versions
+          echo '<settings><mirrors><mirror><id>google-central</id><url>https://maven-central.storage-download.googleapis.com/maven2/</url><mirrorOf>central</mirrorOf></mirror></mirrors></settings>' > /tmp/mirror.xml
+          mvn -B -q -fn -DskipTests -gs /tmp/mirror.xml $([ -f .mvn/settings.xml ] && echo '-s .mvn/settings.xml') dependency:go-offline | tee /tmp/mvn.log || true
+          ! grep -q '\[ERROR\]' /tmp/mvn.log || echo "::warning::Some Maven dependencies could not be resolved; scan depth may be reduced"
         fi
+        trivy fs --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --offline-scan --format json -o /tmp/t.json .
+        jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' /tmp/t.json | sort -u > "trivy-${GITHUB_REPOSITORY##*/}-code-report.tsv"
 
-        # --- fs: lockfile dependencies ---
-        trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --offline-scan \
-          --format json -o trivy-report.json .
-        jq '.Results = ((.Results // []) | map(. + {ScanSrc: "fs"}))' trivy-report.json > combined.json
-
-        # --- image: base images from Dockerfiles ---
-        find . \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name 'Dockerfile-*' \) -not -path '*/node_modules/*' -not -path './.git/*' > dfs.txt || : > dfs.txt
-        : > aliases.txt
-        : > imgs.txt
-        while IFS= read -r df; do
-          awk 'toupper($1)=="FROM" { if (toupper($3)=="AS") print $4; if (toupper($4)=="AS") print $5 }' "$df" >> aliases.txt
-          awk 'toupper($1)=="FROM" { i=$2; if (i ~ /^--/) i=$3; print i }' "$df" >> imgs.txt
-        done < dfs.txt
-        sort -u imgs.txt -o imgs.txt
-        while IFS= read -r img; do
-          [ -z "$img" ] && continue
-          [ "$img" = "scratch" ] && continue
+        out="trivy-${GITHUB_REPOSITORY##*/}-docker-report.tsv"; : > "$out"
+        find . -name 'Dockerfile*' -not -path './.git/*' -not -path '*/node_modules/*' -print0 |
+          xargs -0 -r awk 'toupper($1)=="FROM" {i=$2; if (i ~ /^--/) i=$3; print i; if (toupper($3)=="AS") print "~"$4; if (toupper($4)=="AS") print "~"$5}' | sort -u > /tmp/from.txt
+        for img in $(grep -v '^~' /tmp/from.txt); do
+          [ "$img" = scratch ] && continue
           case "$img" in *'$'*) echo "::warning::Skipping base image with unresolved variable: ${img}"; continue ;; esac
-          grep -qxF "$img" aliases.txt && continue
-          echo "Scanning base image ${img}"
-          if trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --format json -o img.json "$img"; then
-            jq --arg s "$img" '.Results = ((.Results // []) | map(. + {ScanSrc: ("image " + $s)}))' img.json > img2.json
-            jq -s '{Results: (.[0].Results + (.[1].Results // []))}' combined.json img2.json > tmp.json && mv tmp.json combined.json
-          else
+          grep -qxF "~$img" /tmp/from.txt && continue
+          trivy image --no-progress --scanners vuln --severity CRITICAL --ignore-unfixed --format json -o /tmp/t.json "$img" &&
+            jq -r --arg img "$img" '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $img] | @tsv' /tmp/t.json >> "$out" ||
             echo "::warning::Base image ${img} could not be scanned (pull/scan error); it was NOT checked"
-          fi
-        done < imgs.txt
+        done
+        sort -u "$out" -o "$out"
 
-        # --- report (deduplicated: one row per unique vulnerability, with occurrence count) ---
-        total=$(jq '[.Results[]?.Vulnerabilities[]?] | length' combined.json)
-        uniq=$(jq '[.Results[]? as $r | $r.Vulnerabilities[]?
-          | [.Severity, ($r.ScanSrc // "fs"), .PkgName, .VulnerabilityID]] | unique | length' combined.json)
-        if [ "$total" -gt 0 ]; then
-          echo ""
-          echo "=== HIGH/CRITICAL findings: ${uniq} unique (${total} occurrences across modules/images) ==="
-          jq -r '[.Results[]? as $r | $r.Vulnerabilities[]?
-              | {s: .Severity, ty: ($r.ScanSrc // "fs"), p: .PkgName, i: .InstalledVersion,
-                 f: (.FixedVersion // "-"), id: .VulnerabilityID}]
-            | group_by([.s, .ty, .p, .id]) | map(.[0] + {n: length}) | sort_by(.s, .ty, .p)
-            | .[] | [.s, .ty, .p, .i + " -> " + .f, .id, "x\(.n)"] | @tsv' combined.json \
-            | column -t -s "$(printf '\t')"
-          echo ""
-          echo "::error::Trivy found ${uniq} unique HIGH/CRITICAL vulnerabilities (${total} occurrences, fs + base images)"
-          exit 1
+    - name: Scan built image
+      if: inputs.scan == 'image'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.maven-token }}
+        GITHUB_ACTOR: ${{ github.actor }}
+      run: |
+        set -euo pipefail
+        docker buildx build --platform linux/amd64 --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN --build-arg GITHUB_ACTOR="$GITHUB_ACTOR" \
+          -f "${{ inputs.dockerfile }}" --output type=oci,dest=/tmp/image.tar "${{ inputs.context }}"
+        out="trivy-${GITHUB_REPOSITORY##*/}-image-report-${{ inputs.image-name }}.tsv"
+        trivy image --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --input /tmp/image.tar --format json -o /tmp/t.json
+        jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' /tmp/t.json | sort -u > "$out"
+
+    - name: Upload code report
+      if: inputs.scan == 'code'
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy-${{ github.event.repository.name }}-code-report
+        path: trivy-*-code-report.tsv
+
+    - name: Upload docker report
+      if: inputs.scan == 'code'
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy-${{ github.event.repository.name }}-docker-report
+        path: trivy-*-docker-report.tsv
+
+    - name: Upload image report
+      if: inputs.scan == 'image'
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy-${{ github.event.repository.name }}-image-report-${{ inputs.image-name }}
+        path: trivy-*-image-report-*.tsv
+
+    - name: Evaluate
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+      run: |
+        set -euo pipefail
+        repo="${GITHUB_REPOSITORY##*/}"
+        if [ "${{ inputs.scan }}" = "code" ]; then
+          c="trivy-${repo}-code-report.tsv"; d="trivy-${repo}-docker-report.tsv"
+          [ -s "$c" ] || [ -s "$d" ] || { echo "No vulnerabilities found."; exit 0; }
+          cat "$c" "$d" | column -t -s "$(printf '\t')"
+          echo "::error::Trivy: $(cut -f1,2,5 "$c" | sort -u | wc -l | tr -d ' ') unique HIGH/CRITICAL in dependencies, $(wc -l < "$d" | tr -d ' ') CRITICAL in Dockerfile base images (see the trivy-${repo}-code-report artifact)"
+        else
+          f="trivy-${repo}-image-report-${IMAGE_NAME}.tsv"
+          [ -s "$f" ] || { echo "No vulnerabilities found."; exit 0; }
+          column -t -s "$(printf '\t')" "$f"
+          echo "::error::Trivy found HIGH/CRITICAL vulnerabilities in the ${IMAGE_NAME} image (report in the ${f%.tsv} artifact)"
         fi
-        echo "No HIGH/CRITICAL vulnerabilities found."
+        exit 1

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -41,8 +41,8 @@ runs:
           mvn -B -q -fn -DskipTests -gs /tmp/mirror.xml $([ -f .mvn/settings.xml ] && echo '-s .mvn/settings.xml') dependency:go-offline | tee /tmp/mvn.log || true
           ! grep -q '\[ERROR\]' /tmp/mvn.log || echo "::warning::Some Maven dependencies could not be resolved; scan depth may be reduced"
         fi
-        trivy fs --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --offline-scan --format json -o /tmp/t.json .
-        jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' /tmp/t.json | sort -u > "trivy-${GITHUB_REPOSITORY##*/}-code-report.tsv"
+        trivy fs --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --offline-scan --format json . |
+          jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' | sort -u > "trivy-${GITHUB_REPOSITORY##*/}-code-report.tsv"
 
         out="trivy-${GITHUB_REPOSITORY##*/}-docker-report.tsv"; : > "$out"
         find . -name 'Dockerfile*' -not -path './.git/*' -not -path '*/node_modules/*' -print0 |
@@ -51,8 +51,8 @@ runs:
           [ "$img" = scratch ] && continue
           case "$img" in *'$'*) echo "::warning::Skipping base image with unresolved variable: ${img}"; continue ;; esac
           grep -qxF "~$img" /tmp/from.txt && continue
-          trivy image --no-progress --scanners vuln --severity CRITICAL --ignore-unfixed --format json -o /tmp/t.json "$img" &&
-            jq -r --arg img "$img" '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $img] | @tsv' /tmp/t.json >> "$out" ||
+          trivy image --no-progress --scanners vuln --severity CRITICAL --ignore-unfixed --format json "$img" |
+            jq -r --arg img "$img" '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $img] | @tsv' >> "$out" ||
             echo "::warning::Base image ${img} could not be scanned (pull/scan error); it was NOT checked"
         done
         sort -u "$out" -o "$out"
@@ -69,8 +69,8 @@ runs:
         docker buildx build --platform linux/amd64 --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN --build-arg GITHUB_ACTOR="$GITHUB_ACTOR" \
           -f "${{ inputs.dockerfile }}" --output type=oci,dest=/tmp/image.tar "${{ inputs.context }}"
         out="trivy-${GITHUB_REPOSITORY##*/}-image-report-${{ inputs.image-name }}.tsv"
-        trivy image --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --input /tmp/image.tar --format json -o /tmp/t.json
-        jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' /tmp/t.json | sort -u > "$out"
+        trivy image --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --input /tmp/image.tar --format json |
+          jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' | sort -u > "$out"
         find . -maxdepth 1 -name 'trivy-*.tsv' -empty -delete
 
     - name: Upload report
@@ -82,21 +82,9 @@ runs:
 
     - name: Evaluate
       shell: bash
-      env:
-        IMAGE_NAME: ${{ inputs.image-name }}
       run: |
         set -euo pipefail
-        repo="${GITHUB_REPOSITORY##*/}"
-        if [ "${{ inputs.scan }}" = "code" ]; then
-          c="trivy-${repo}-code-report.tsv"; d="trivy-${repo}-docker-report.tsv"
-          [ -f "$c" ] || c=/dev/null; [ -f "$d" ] || d=/dev/null
-          [ -s "$c" ] || [ -s "$d" ] || { echo "No vulnerabilities found."; exit 0; }
-          cat "$c" "$d" | column -t -s "$(printf '\t')"
-          echo "::error::Trivy: $(cut -f1,2,5 "$c" | sort -u | wc -l | tr -d ' ') unique HIGH/CRITICAL in dependencies, $(wc -l < "$d" | tr -d ' ') CRITICAL in Dockerfile base images (see the trivy-${repo}-code-report artifact)"
-        else
-          f="trivy-${repo}-image-report-${IMAGE_NAME}.tsv"
-          [ -s "$f" ] || { echo "No vulnerabilities found."; exit 0; }
-          column -t -s "$(printf '\t')" "$f"
-          echo "::error::Trivy found HIGH/CRITICAL vulnerabilities in the ${IMAGE_NAME} image (report in the ${f%.tsv} artifact)"
-        fi
+        files=$(ls trivy-*.tsv 2>/dev/null) || { echo "No vulnerabilities found."; exit 0; }
+        column -t -s "$(printf '\t')" $files
+        echo "::error::Trivy found $(cat $files | wc -l | tr -d ' ') HIGH/CRITICAL vulnerabilities in: ${files//$'\n'/, } (full report in the run artifacts)"
         exit 1

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -56,6 +56,7 @@ runs:
             echo "::warning::Base image ${img} could not be scanned (pull/scan error); it was NOT checked"
         done
         sort -u "$out" -o "$out"
+        find . -maxdepth 1 -name 'trivy-*.tsv' -empty -delete
 
     - name: Scan built image
       if: inputs.scan == 'image'
@@ -70,6 +71,7 @@ runs:
         out="trivy-${GITHUB_REPOSITORY##*/}-image-report-${{ inputs.image-name }}.tsv"
         trivy image --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --input /tmp/image.tar --format json -o /tmp/t.json
         jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' /tmp/t.json | sort -u > "$out"
+        find . -maxdepth 1 -name 'trivy-*.tsv' -empty -delete
 
     - name: Upload code report
       if: inputs.scan == 'code'
@@ -77,6 +79,7 @@ runs:
       with:
         name: trivy-${{ github.event.repository.name }}-code-report
         path: trivy-*-code-report.tsv
+        if-no-files-found: ignore
 
     - name: Upload docker report
       if: inputs.scan == 'code'
@@ -84,6 +87,7 @@ runs:
       with:
         name: trivy-${{ github.event.repository.name }}-docker-report
         path: trivy-*-docker-report.tsv
+        if-no-files-found: ignore
 
     - name: Upload image report
       if: inputs.scan == 'image'
@@ -91,6 +95,7 @@ runs:
       with:
         name: trivy-${{ github.event.repository.name }}-image-report-${{ inputs.image-name }}
         path: trivy-*-image-report-*.tsv
+        if-no-files-found: ignore
 
     - name: Evaluate
       shell: bash
@@ -101,6 +106,7 @@ runs:
         repo="${GITHUB_REPOSITORY##*/}"
         if [ "${{ inputs.scan }}" = "code" ]; then
           c="trivy-${repo}-code-report.tsv"; d="trivy-${repo}-docker-report.tsv"
+          [ -f "$c" ] || c=/dev/null; [ -f "$d" ] || d=/dev/null
           [ -s "$c" ] || [ -s "$d" ] || { echo "No vulnerabilities found."; exit 0; }
           cat "$c" "$d" | column -t -s "$(printf '\t')"
           echo "::error::Trivy: $(cut -f1,2,5 "$c" | sort -u | wc -l | tr -d ' ') unique HIGH/CRITICAL in dependencies, $(wc -l < "$d" | tr -d ' ') CRITICAL in Dockerfile base images (see the trivy-${repo}-code-report artifact)"

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -1,4 +1,4 @@
-name: "Scan"
+name: "Vulnerability Scan"
 description: "Trivy PR security scans. scan: code = repo dependencies (HIGH/CRITICAL) + Dockerfile base images (CRITICAL), image = image built in the pipeline (HIGH/CRITICAL). Each scan uploads its TSV report as an artifact"
 
 inputs:

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -1,4 +1,4 @@
-name: "Trivy"
+name: "Scan"
 description: "Trivy PR security scans. scan: code = repo dependencies (HIGH/CRITICAL) + Dockerfile base images (CRITICAL), image = image built in the pipeline (HIGH/CRITICAL). Each scan uploads its TSV report as an artifact"
 
 inputs:

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -86,5 +86,5 @@ runs:
         set -euo pipefail
         files=$(ls trivy-*.tsv 2>/dev/null) || { echo "No vulnerabilities found."; exit 0; }
         column -t -s "$(printf '\t')" $files
-        echo "::error::Trivy found $(cat $files | wc -l | tr -d ' ') HIGH/CRITICAL vulnerabilities in: ${files//$'\n'/, } (full report in the run artifacts)"
+        echo "::error::Trivy found $(cut -f1,2,5 $files | sort -u | wc -l | tr -d ' ') unique HIGH/CRITICAL vulnerabilities ($(cat $files | wc -l | tr -d ' ') occurrences across modules) in: ${files//$'\n'/, } (full report in the run artifacts)"
         exit 1

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -55,6 +55,14 @@ runs:
         [ -n "$skip" ] && targs+=(--skip-dirs "$skip")
         trivy fs "${targs[@]}" "$dir" |
           jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' | sort -u > "trivy-${GITHUB_REPOSITORY##*/}-code-report.tsv"
+        f="trivy-${GITHUB_REPOSITORY##*/}-code-report.tsv"
+        while IFS=$'\t' read -r sev pkg inst fixv cve tgt; do
+          o="-"
+          case "$tgt" in *pom.xml)
+            grep -q "<artifactId>${pkg##*:}</artifactId>" "$dir/$tgt" 2>/dev/null && o=direct || o=transitive ;;
+          esac
+          printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$sev" "$pkg" "$inst" "$fixv" "$cve" "$tgt" "$o"
+        done < "$f" > "$f.tmp" && mv "$f.tmp" "$f"
 
         out="trivy-${GITHUB_REPOSITORY##*/}-docker-report.tsv"; : > "$out"
         fargs=(-name 'Dockerfile*' -not -path '*/.git/*' -not -path '*/node_modules/*')
@@ -81,7 +89,7 @@ runs:
       run: |
         set -euo pipefail
         docker buildx build --platform linux/amd64 --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN --build-arg GITHUB_ACTOR="$GITHUB_ACTOR" \
-          -f "${{ inputs.dockerfile }}" --output type=oci,dest=/tmp/image.tar "${{ inputs.context }}"
+          -f "${{ inputs.dockerfile }}" --output type=docker,dest=/tmp/image.tar "${{ inputs.context }}"
         out="trivy-${GITHUB_REPOSITORY##*/}-image-report-${{ inputs.image-name }}.tsv"
         trivy image --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --input /tmp/image.tar --format json |
           jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' | sort -u > "$out"

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -1,0 +1,87 @@
+name: "Trivy"
+description: "PR security gate: scans repository dependencies (fs) and Dockerfile base images, prints findings and fails on HIGH/CRITICAL with a fix available"
+
+inputs:
+  maven-token:
+    description: "Token Maven uses to read internal artifacts from GitHub Packages (defaults to the workflow token, which cannot read other repos' packages)"
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Trivy
+      uses: aquasecurity/setup-trivy@v0.3.1
+      with:
+        version: v0.73.0
+        cache: true
+
+    - name: Scan and evaluate
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.maven-token }}
+        GITHUB_ACTOR: ${{ github.actor }}
+      run: |
+        set -euo pipefail
+
+        # --- maven: resolve deps into ~/.m2 via Google's Central mirror so trivy
+        #     can analyze parent-managed versions fully offline (no rate limits) ---
+        if [ -f pom.xml ]; then
+          printf '%s\n' \
+            '<settings><mirrors><mirror>' \
+            '  <id>google-central</id>' \
+            '  <name>Google mirror of Maven Central</name>' \
+            '  <url>https://maven-central.storage-download.googleapis.com/maven2/</url>' \
+            '  <mirrorOf>central</mirrorOf>' \
+            '</mirror></mirrors></settings>' > /tmp/central-mirror.xml
+          margs=(-B -q -fn -DskipTests -gs /tmp/central-mirror.xml dependency:go-offline)
+          [ -f .mvn/settings.xml ] && margs+=(-s .mvn/settings.xml)
+          mvn "${margs[@]}" || echo "::warning::Maven dependency resolution incomplete; pom.xml scan depth may be reduced"
+        fi
+
+        # --- fs: lockfile dependencies ---
+        trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --offline-scan \
+          --format json -o trivy-report.json .
+        jq '.Results = ((.Results // []) | map(. + {ScanSrc: "fs"}))' trivy-report.json > combined.json
+
+        # --- image: base images from Dockerfiles ---
+        find . \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name 'Dockerfile-*' \) -not -path '*/node_modules/*' -not -path './.git/*' > dfs.txt || : > dfs.txt
+        : > aliases.txt
+        : > imgs.txt
+        while IFS= read -r df; do
+          awk 'toupper($1)=="FROM" { if (toupper($3)=="AS") print $4; if (toupper($4)=="AS") print $5 }' "$df" >> aliases.txt
+          awk 'toupper($1)=="FROM" { i=$2; if (i ~ /^--/) i=$3; print i }' "$df" >> imgs.txt
+        done < dfs.txt
+        sort -u imgs.txt -o imgs.txt
+        while IFS= read -r img; do
+          [ -z "$img" ] && continue
+          [ "$img" = "scratch" ] && continue
+          case "$img" in *'$'*) continue ;; esac
+          grep -qxF "$img" aliases.txt && continue
+          echo "Scanning base image ${img}"
+          if trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --format json -o img.json "$img"; then
+            jq --arg s "$img" '.Results = ((.Results // []) | map(. + {ScanSrc: ("image " + $s)}))' img.json > img2.json
+            jq -s '{Results: (.[0].Results + (.[1].Results // []))}' combined.json img2.json > tmp.json && mv tmp.json combined.json
+          else
+            echo "skip ${img}"
+          fi
+        done < imgs.txt
+
+        # --- report (deduplicated: one row per unique vulnerability, with occurrence count) ---
+        total=$(jq '[.Results[]?.Vulnerabilities[]?] | length' combined.json)
+        uniq=$(jq '[.Results[]? as $r | $r.Vulnerabilities[]?
+          | [.Severity, ($r.ScanSrc // "fs"), .PkgName, .VulnerabilityID]] | unique | length' combined.json)
+        if [ "$total" -gt 0 ]; then
+          echo ""
+          echo "=== HIGH/CRITICAL findings: ${uniq} unique (${total} occurrences across modules/images) ==="
+          jq -r '[.Results[]? as $r | $r.Vulnerabilities[]?
+              | {s: .Severity, ty: ($r.ScanSrc // "fs"), p: .PkgName, i: .InstalledVersion,
+                 f: (.FixedVersion // "-"), id: .VulnerabilityID}]
+            | group_by([.s, .ty, .p, .id]) | map(.[0] + {n: length}) | sort_by(.s, .ty, .p)
+            | .[] | [.s, .ty, .p, .i + " -> " + .f, .id, "x\(.n)"] | @tsv' combined.json \
+            | column -t -s "$(printf '\t')"
+          echo ""
+          echo "::error::Trivy found ${uniq} unique HIGH/CRITICAL vulnerabilities (${total} occurrences, fs + base images)"
+          exit 1
+        fi
+        echo "No HIGH/CRITICAL vulnerabilities found."

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -36,7 +36,10 @@ runs:
             '</mirror></mirrors></settings>' > /tmp/central-mirror.xml
           margs=(-B -q -fn -DskipTests -gs /tmp/central-mirror.xml dependency:go-offline)
           [ -f .mvn/settings.xml ] && margs+=(-s .mvn/settings.xml)
-          mvn "${margs[@]}" || echo "::warning::Maven dependency resolution incomplete; pom.xml scan depth may be reduced"
+          mvn "${margs[@]}" | tee /tmp/mvn.log || true
+          if grep -q '\[ERROR\]' /tmp/mvn.log; then
+            echo "::warning::Some Maven dependencies could not be resolved; pom.xml scan depth may be reduced"
+          fi
         fi
 
         # --- fs: lockfile dependencies ---
@@ -56,14 +59,14 @@ runs:
         while IFS= read -r img; do
           [ -z "$img" ] && continue
           [ "$img" = "scratch" ] && continue
-          case "$img" in *'$'*) continue ;; esac
+          case "$img" in *'$'*) echo "::warning::Skipping base image with unresolved variable: ${img}"; continue ;; esac
           grep -qxF "$img" aliases.txt && continue
           echo "Scanning base image ${img}"
           if trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --format json -o img.json "$img"; then
             jq --arg s "$img" '.Results = ((.Results // []) | map(. + {ScanSrc: ("image " + $s)}))' img.json > img2.json
             jq -s '{Results: (.[0].Results + (.[1].Results // []))}' combined.json img2.json > tmp.json && mv tmp.json combined.json
           else
-            echo "skip ${img}"
+            echo "::warning::Base image ${img} could not be scanned (pull/scan error); it was NOT checked"
           fi
         done < imgs.txt
 

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Install Trivy
       uses: aquasecurity/setup-trivy@v0.3.1
       with:
-        version: v0.73.0
+        version: v0.74.0
         cache: true
 
     - name: Scan dependencies and Dockerfile base images

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -73,28 +73,11 @@ runs:
         jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' /tmp/t.json | sort -u > "$out"
         find . -maxdepth 1 -name 'trivy-*.tsv' -empty -delete
 
-    - name: Upload code report
-      if: inputs.scan == 'code'
+    - name: Upload report
       uses: actions/upload-artifact@v4
       with:
-        name: trivy-${{ github.event.repository.name }}-code-report
-        path: trivy-*-code-report.tsv
-        if-no-files-found: ignore
-
-    - name: Upload docker report
-      if: inputs.scan == 'code'
-      uses: actions/upload-artifact@v4
-      with:
-        name: trivy-${{ github.event.repository.name }}-docker-report
-        path: trivy-*-docker-report.tsv
-        if-no-files-found: ignore
-
-    - name: Upload image report
-      if: inputs.scan == 'image'
-      uses: actions/upload-artifact@v4
-      with:
-        name: trivy-${{ github.event.repository.name }}-image-report-${{ inputs.image-name }}
-        path: trivy-*-image-report-*.tsv
+        name: ${{ inputs.scan == 'code' && format('trivy-{0}-code-report', github.event.repository.name) || format('trivy-{0}-image-report-{1}', github.event.repository.name, inputs.image-name) }}
+        path: trivy-*.tsv
         if-no-files-found: ignore
 
     - name: Evaluate

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -10,8 +10,16 @@ inputs:
     required: false
     default: ${{ github.token }}
   image-name:
-    description: "Service name from the build matrix (scan: image)"
+    description: "Service name from the matrix; used in the artifact name"
     required: false
+  path:
+    description: "Directory to scan (scan: code), e.g. a single service; defaults to the whole repo"
+    required: false
+    default: "."
+  skip-dirs:
+    description: "Comma-separated directories to exclude from the code scan (e.g. service dirs already scanned by the matrix)"
+    required: false
+    default: ""
   dockerfile:
     description: "Path to the service Dockerfile (scan: image)"
     required: false
@@ -36,16 +44,22 @@ runs:
         GITHUB_ACTOR: ${{ github.actor }}
       run: |
         set -euo pipefail
-        if [ -f pom.xml ]; then  # warm ~/.m2 via Google's Central mirror so trivy sees parent-managed versions
+        dir="${{ inputs.path }}"
+        if [ -f "$dir/pom.xml" ]; then  # warm ~/.m2 via Google's Central mirror so trivy sees parent-managed versions
           echo '<settings><mirrors><mirror><id>google-central</id><url>https://maven-central.storage-download.googleapis.com/maven2/</url><mirrorOf>central</mirrorOf></mirror></mirrors></settings>' > /tmp/mirror.xml
-          mvn -B -q -fn -DskipTests -gs /tmp/mirror.xml $([ -f .mvn/settings.xml ] && echo '-s .mvn/settings.xml') dependency:go-offline | tee /tmp/mvn.log || true
+          mvn -B -q -fn -DskipTests -gs /tmp/mirror.xml -f "$dir/pom.xml" $([ -f .mvn/settings.xml ] && echo '-s .mvn/settings.xml') dependency:go-offline | tee /tmp/mvn.log || true
           ! grep -q '\[ERROR\]' /tmp/mvn.log || echo "::warning::Some Maven dependencies could not be resolved; scan depth may be reduced"
         fi
-        trivy fs --no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --offline-scan --format json . |
+        skip="${{ inputs.skip-dirs }}"
+        targs=(--no-progress --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --offline-scan --format json)
+        [ -n "$skip" ] && targs+=(--skip-dirs "$skip")
+        trivy fs "${targs[@]}" "$dir" |
           jq -r '.Results[]? as $r | $r.Vulnerabilities[]? | [.Severity, .PkgName, .InstalledVersion, (.FixedVersion // "-"), .VulnerabilityID, $r.Target] | @tsv' | sort -u > "trivy-${GITHUB_REPOSITORY##*/}-code-report.tsv"
 
         out="trivy-${GITHUB_REPOSITORY##*/}-docker-report.tsv"; : > "$out"
-        find . -name 'Dockerfile*' -not -path './.git/*' -not -path '*/node_modules/*' -print0 |
+        fargs=(-name 'Dockerfile*' -not -path '*/.git/*' -not -path '*/node_modules/*')
+        [ -n "$skip" ] && for d in ${skip//,/ }; do fargs+=(-not -path "*/${d}/*" -not -path "${d}/*"); done
+        find "$dir" "${fargs[@]}" -print0 |
           xargs -0 -r awk 'toupper($1)=="FROM" {i=$2; if (i ~ /^--/) i=$3; print i; if (toupper($3)=="AS") print "~"$4; if (toupper($4)=="AS") print "~"$5}' | sort -u > /tmp/from.txt
         for img in $(grep -v '^~' /tmp/from.txt); do
           [ "$img" = scratch ] && continue
@@ -76,7 +90,7 @@ runs:
     - name: Upload report
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.scan == 'code' && format('trivy-{0}-code-report', github.event.repository.name) || format('trivy-{0}-image-report-{1}', github.event.repository.name, inputs.image-name) }}
+        name: ${{ inputs.scan == 'code' && (inputs.image-name && format('scan_code-{0}', inputs.image-name) || 'scan_code') || format('scan_image-{0}', inputs.image-name) }}
         path: trivy-*.tsv
         if-no-files-found: ignore
 

--- a/.github/steps/trivy/action.yml
+++ b/.github/steps/trivy/action.yml
@@ -82,9 +82,11 @@ runs:
 
     - name: Evaluate
       shell: bash
+      env:
+        ARTIFACT: ${{ inputs.scan == 'code' && 'scan_code' || 'scan_image' }}
       run: |
         set -euo pipefail
         files=$(ls trivy-*.tsv 2>/dev/null) || { echo "No vulnerabilities found."; exit 0; }
         column -t -s "$(printf '\t')" $files
-        echo "::error::Trivy found $(cut -f1,2,5 $files | sort -u | wc -l | tr -d ' ') unique HIGH/CRITICAL vulnerabilities ($(cat $files | wc -l | tr -d ' ') occurrences across modules) in: ${files//$'\n'/, } (full report in the run artifacts)"
+        echo "::error::Trivy found $(cut -f1,2,5 $files | sort -u | wc -l | tr -d ' ') unique HIGH/CRITICAL vulnerabilities ($(cat $files | wc -l | tr -d ' ') occurrences across modules) — full report in the ${ARTIFACT} artifact"
         exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
 
   all-checks:
     name: "All Checks"
-    needs: [build_client, trivy_scan]
+    needs: [build_client]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,18 +64,18 @@ jobs:
       - name: Setup MSBuild
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
-      
+
       - name: Setup Visual Studio Build Tools
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: ${{ matrix.os_arch }}      
+          arch: ${{ matrix.os_arch }}
 
       - name: Install macOS Dependencies
         if: runner.os == 'macOS'
         run: brew install openssl jpeg zlib
         shell: bash
-      
+
       - name: Build MeshAgent for Windows ${{ matrix.os_arch }} with MSBuild
         if: matrix.os == 'windows-latest'
         run: msbuild MeshAgent-2022.sln -p:Configuration=Release -p:Platform=${{ matrix.os_arch }} -p:WindowsTargetPlatformVersion=10.0.26100.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,20 @@ jobs:
         with:
           scan: code
 
+  trivy_report:
+    name: "Trivy Report"
+    runs-on: ubuntu-latest
+    needs: [trivy_code]
+    if: always()
+    steps:
+      - name: Merge all scan reports into one artifact
+        continue-on-error: true
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: trivy-${{ github.event.repository.name }}-report
+          pattern: trivy-*-report*
+          delete-merged: true
+
   all-checks:
     name: "All Checks"
     needs: [build_client]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,8 +88,8 @@ jobs:
           make macos ARCHID=${{ matrix.archid }}
         shell: bash
 
-  trivy_scan:
-    name: "Trivy Scan"
+  trivy_code:
+    name: "Trivy Code Scan"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -102,8 +102,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Trivy scan (fs + base images)
+      - name: Trivy scan (dependencies + Dockerfile base images)
         uses: ./.github/steps/trivy
+        with:
+          scan: code
 
   all-checks:
     name: "All Checks"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,3 +87,29 @@ jobs:
           echo "Building MeshAgent for macOS ${{ matrix.os_arch }}"
           make macos ARCHID=${{ matrix.archid }}
         shell: bash
+
+  trivy_scan:
+    name: "Trivy Scan"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && !github.event.pull_request.draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Trivy scan (fs + base images)
+        uses: ./.github/steps/trivy
+
+  all-checks:
+    name: "All Checks"
+    needs: [build_client, trivy_scan]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+      - run: echo "All checks passed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Trivy scan (dependencies + Dockerfile base images)
+      - name: Scan code
         uses: ./.github/steps/trivy
         with:
           scan: code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,8 +88,8 @@ jobs:
           make macos ARCHID=${{ matrix.archid }}
         shell: bash
 
-  trivy_code:
-    name: "Trivy Code Scan"
+  scan_code:
+    name: "Scan Code"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -107,18 +107,18 @@ jobs:
         with:
           scan: code
 
-  trivy_report:
-    name: "Trivy Report"
+  report:
+    name: "Report"
     runs-on: ubuntu-latest
-    needs: [trivy_code]
-    if: always()
+    needs: [scan_code]
+    if: always() && github.event_name == 'pull_request'
     steps:
-      - name: Merge all scan reports into one artifact
+      - name: Merge code scan report
         continue-on-error: true
         uses: actions/upload-artifact/merge@v4
         with:
-          name: trivy-${{ github.event.repository.name }}-report
-          pattern: trivy-*-report*
+          name: scan_code
+          pattern: trivy-*-code-report*
           delete-merged: true
 
   all-checks:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Trivy scan (fs + base images)
         uses: ./.github/steps/trivy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,8 +88,8 @@ jobs:
           make macos ARCHID=${{ matrix.archid }}
         shell: bash
 
-  scan_code:
-    name: "Scan Code"
+  scan:
+    name: "Scan"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -106,20 +106,6 @@ jobs:
         uses: ./.github/steps/trivy
         with:
           scan: code
-
-  report:
-    name: "Report"
-    runs-on: ubuntu-latest
-    needs: [scan_code]
-    if: always() && github.event_name == 'pull_request'
-    steps:
-      - name: Merge code scan report
-        continue-on-error: true
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: scan_code
-          pattern: trivy-*-code-report*
-          delete-merged: true
 
   all-checks:
     name: "All Checks"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# Vulnerabilities to skip in the Trivy scan: one CVE/GHSA id per line, e.g.:
+#
+# CVE-2026-12345


### PR DESCRIPTION
Adds a Trivy-based PR security gate:
- scans repository dependencies (lockfiles / pom.xml) and Dockerfile base images
- fails the pipeline on HIGH/CRITICAL vulnerabilities with a fix available
- findings are deduplicated across modules; suppressions go to .trivyignore with a justification comment
- wired into All Checks so merging is blocked when the scan is red

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated security scanning for project dependencies and Docker base images.
  * Scans identify unfixed high- and critical-severity vulnerabilities and report occurrence counts.
  * Pull request checks now fail when vulnerabilities or other required checks are detected.

* **Configuration**
  * Added support for excluding documented vulnerability IDs from scans.
  * Maven authentication can be configured for dependency scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->