### PR TITLE
Ship CoreModule.js in both release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,20 +223,24 @@ jobs:
       - name: Prepare release artifacts
         run: |
           set -e
+          [ -f CoreModule.js ] || { echo "::error::CoreModule.js missing from checkout"; exit 1; }
           mkdir -p final-artifacts/clients
 
           # macOS - reconstruct .app bundle and archive
+          # CoreModule.js goes next to the .app (agent loads it from there); inside would break the codesign seal
           if [ -d "release-artifacts/meshagent-mac-universal/Contents" ]; then
             mkdir -p release-artifacts/meshagent-mac-universal-app
             mv release-artifacts/meshagent-mac-universal release-artifacts/meshagent-mac-universal-app/MeshAgent.app
+            cp CoreModule.js release-artifacts/meshagent-mac-universal-app/
             tar -czvf "final-artifacts/clients/meshagent-macos-universal.tar.gz" \
-              -C "release-artifacts/meshagent-mac-universal-app" MeshAgent.app
+              -C "release-artifacts/meshagent-mac-universal-app" MeshAgent.app CoreModule.js
           fi
 
           # Windows
           if [ -d "release-artifacts/meshagent-windows-amd64" ]; then
+            cp CoreModule.js release-artifacts/meshagent-windows-amd64/
             (cd "release-artifacts/meshagent-windows-amd64" && \
-              zip "${GITHUB_WORKSPACE}/final-artifacts/clients/meshagent-windows-amd64.zip" ${{ env.BINARY_NAME }}.exe)
+              zip "${GITHUB_WORKSPACE}/final-artifacts/clients/meshagent-windows-amd64.zip" "${BINARY_NAME}.exe" CoreModule.js)
           fi
 
           # Verify all expected artifacts exist
@@ -254,6 +258,7 @@ jobs:
           ## MeshAgent Clients
           - **macOS** (Universal App Bundle): \`meshagent-macos-universal.tar.gz\` - Extract and run MeshAgent.app
           - **Windows** (amd64): \`meshagent-windows-amd64.zip\`
+          - Both archives include \`CoreModule.js\` (OpenFrame agent core)
           EOF
 
       - name: Create Release


### PR DESCRIPTION
## Why

Deployed OpenFrame machines currently receive the mesh agent's JS core from a frozen snapshot baked into the openframe-client JAR (`ToolAgentFileController`, marked `TODO: remove after github artifact is implemented`). Edits to `CoreModule.js` in this repo never reach machines. This PR is step 1 of retiring that stopgap: make the release archives carry `CoreModule.js` so the openframe-client can install/update it as a versioned GITHUB asset (oss-lib config flip lands separately).

## What

`release.yml` → `Prepare release artifacts`:
- Windows zip: add `CoreModule.js` at the archive root next to `meshagent.exe`.
- macOS tar.gz: add `CoreModule.js` as a **sibling of `MeshAgent.app`** — deliberately outside the bundle so the codesign/notarization seal stays intact; this is also exactly where the agent looks for it in OpenFrame mode (`agentcore.c` builds the path "next to .app").
- Preflight check that `CoreModule.js` exists in the checkout; release-notes line listing the new archive content.
- Hardened the zip line to use `"${BINARY_NAME}.exe"` (shell env) instead of raw `${{ env.BINARY_NAME }}` interpolation.

Windows Authenticode signing is unaffected — it signs the bare `.exe` one job earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release packages now include the OpenFrame agent core.
  * Both macOS and Windows client archives contain the required core module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->