### PR TITLE
Restore upstream server core execution in OpenFrame mode

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -2481,73 +2481,6 @@ char* MeshAgent_MakeAbsolutePathEx(char *basePath, char *localPath, int escapeBa
 	return(ILibScratchPad2);
 }
 
-// TODO: make as external cmd arg and configure from openframe agent
-// Build path to CoreModule.js for OpenFrame mode with fallback logic:
-// 1. First try next to the executable
-// 2. If not found and we're in a .app bundle, try next to the .app
-// Returns: Path to CoreModule.js (uses ILibScratchPad for the result)
-static char* buildOpenframeCoreModulePath(const char* exePath)
-{
-	char* lastSep;
-	FILE* testFile;
-
-#ifdef WIN32
-	lastSep = strrchr(exePath, '\\');
-	if (lastSep != NULL)
-	{
-		snprintf(ILibScratchPad, sizeof(ILibScratchPad), "%.*s\\CoreModule.js",
-			(int)(lastSep - exePath), exePath);
-	}
-	else
-	{
-		strcpy_s(ILibScratchPad, sizeof(ILibScratchPad), "CoreModule.js");
-	}
-#else
-	// First try: next to the executable
-	lastSep = strrchr(exePath, '/');
-	if (lastSep != NULL)
-	{
-		snprintf(ILibScratchPad, sizeof(ILibScratchPad), "%.*s/CoreModule.js",
-			(int)(lastSep - exePath), exePath);
-	}
-	else
-	{
-		strcpy_s(ILibScratchPad, sizeof(ILibScratchPad), "CoreModule.js");
-	}
-
-	// Check if file exists at first location
-	testFile = fopen(ILibScratchPad, "rb");
-	if (testFile != NULL)
-	{
-		fclose(testFile);
-		return ILibScratchPad;
-	}
-
-	// Second try: if we're in a .app bundle, look next to the .app
-	// Path pattern: /path/to/App.app/Contents/MacOS/binary
-	char* appMarker = strstr(exePath, ".app/Contents/MacOS/");
-	if (appMarker != NULL)
-	{
-		// Find the start of .app (go back to find the app name)
-		char* appStart = appMarker;
-		while (appStart > exePath && *(appStart - 1) != '/') appStart--;
-
-		// Build path: /path/to/CoreModule.js (next to .app)
-		snprintf(ILibScratchPad, sizeof(ILibScratchPad), "%.*s/CoreModule.js",
-			(int)(appStart - exePath - 1), exePath);
-
-		testFile = fopen(ILibScratchPad, "rb");
-		if (testFile != NULL)
-		{
-			fclose(testFile);
-			return ILibScratchPad;
-		}
-	}
-#endif
-
-	return ILibScratchPad;
-}
-
 #ifndef MICROSTACK_NOTLS
 int agent_GenerateCertificates(MeshAgentHostContainer *agent, char* certfile)
 {
@@ -3648,49 +3581,16 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 						break;
 					}
 
-					// Check if we are in openFrame mode
-					if (agent->openFrameMode)
+					// Stop the current JavaScript core if present and launch the new one.
+					// JavaScript located at (cmd + 36) of length (cmdLen - 36)
+					//printf("CORE: Restart\r\n");
+					ILibRemoteLogging_printf(ILibChainGetLogger(agent->chain), ILibRemoteLogging_Modules_Microstack_Generic | ILibRemoteLogging_Modules_ConsolePrint,
+						ILibRemoteLogging_Flags_VerbosityLevel_1, "MeshCore: Restart");
+					if ((coreException = ScriptEngine_Restart(agent, MeshAgent_JavaCore_ContextGuid, coremodule + 4, (int)coremoduleLen - 4)) != NULL)
 					{
-						// For openFrame mode: start CoreModule from file instead of server data
-						char* coreModulePath = buildOpenframeCoreModulePath(agent->exePath);
-						FILE *file = fopen(coreModulePath, "rb");
-						if (file != NULL) {
-							// Get file size
-							fseek(file, 0, SEEK_END);
-							int fileSize = ftell(file);
-							fseek(file, 0, SEEK_SET);
-
-							// Allocate memory and read file
-							char* fileCoreModule = (char*)ILibMemory_Allocate(fileSize, 0, NULL, NULL);
-							if (fileCoreModule != NULL) {
-								size_t bytesRead = fread(fileCoreModule, 1, fileSize, file);
-								if (bytesRead == fileSize) {
-									ILibRemoteLogging_printf(ILibChainGetLogger(agent->chain), ILibRemoteLogging_Modules_Microstack_Generic | ILibRemoteLogging_Modules_ConsolePrint,
-										ILibRemoteLogging_Flags_VerbosityLevel_1, "MeshCore: Restart (OpenFrame from file)");
-									if ((coreException = ScriptEngine_Restart(agent, MeshAgent_JavaCore_ContextGuid, fileCoreModule, fileSize)) != NULL)
-									{
-										ILibRemoteLogging_printf(ILibChainGetLogger(agent->chain), ILibRemoteLogging_Modules_Microstack_Generic | ILibRemoteLogging_Modules_ConsolePrint,
-											ILibRemoteLogging_Flags_VerbosityLevel_1, "MeshCore: Error (OpenFrame): %s", coreException);
-									}
-								}
-								ILibMemory_Free(fileCoreModule);
-							}
-							fclose(file);
-						}
-					}
-					else
-					{
-						// Stop the current JavaScript core if present and launch the new one.
-						// JavaScript located at (cmd + 36) of length (cmdLen - 36)
-						//printf("CORE: Restart\r\n");
 						ILibRemoteLogging_printf(ILibChainGetLogger(agent->chain), ILibRemoteLogging_Modules_Microstack_Generic | ILibRemoteLogging_Modules_ConsolePrint,
-							ILibRemoteLogging_Flags_VerbosityLevel_1, "MeshCore: Restart");
-						if ((coreException = ScriptEngine_Restart(agent, MeshAgent_JavaCore_ContextGuid, coremodule + 4, (int)coremoduleLen - 4)) != NULL)
-						{
-							ILibRemoteLogging_printf(ILibChainGetLogger(agent->chain), ILibRemoteLogging_Modules_Microstack_Generic | ILibRemoteLogging_Modules_ConsolePrint,
-								ILibRemoteLogging_Flags_VerbosityLevel_1, "MeshCore: Error: %s", coreException);
-							// TODO: Ylian: New Java Core threw an exception... Exception String is stored in 'coreException'
-						}
+							ILibRemoteLogging_Flags_VerbosityLevel_1, "MeshCore: Error: %s", coreException);
+						// TODO: Ylian: New Java Core threw an exception... Exception String is stored in 'coreException'
 					}
 
 					// Since we did a big write to the data store, good time to compact the store
@@ -3744,7 +3644,7 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 		}
 		case MeshCommand_CoreOk: // Message from the server indicating our meshcore is ok. No update needed.
 		{
-			printf("Received CoreOk from server (coreTimeout=%p)\n", agent->coreTimeout);
+			printf("Server verified meshcore...");
 
 			duk_eval_string(agent->meshCoreCtx, "_MSH().setuid;");
 			if (duk_is_null_or_undefined(agent->meshCoreCtx, -1) == 0)
@@ -3766,7 +3666,6 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 
 			if (agent->coreTimeout != NULL)
 			{
-				printf("Start meshcore. Openframe mode: %d, coreTimeout: %p\n", agent->openFrameMode, agent->coreTimeout);
 				// Cancel the timeout
 				duk_push_global_object(agent->meshCoreCtx);					// [g]
 				duk_get_prop_string(agent->meshCoreCtx, -1, "clearTimeout");// [g][clearTimeout]
@@ -3796,69 +3695,16 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 					}
 					else
 					{
-						if (agent->openFrameMode)
-						{
-							printf("[COREMODULE-2] === CoreModule loading (timeout handler) ===\n");
-							printf("[COREMODULE-2] OpenFrame mode: loading CoreModule from FILE\n");
-							printf("[COREMODULE-2] exePath: %s\n", agent->exePath ? agent->exePath : "NULL");
-
-							char* coreModulePath = buildOpenframeCoreModulePath(agent->exePath);
-							printf("[COREMODULE-2] CoreModule path: %s\n", coreModulePath);
-
-							FILE *file = fopen(coreModulePath, "rb");
-							if (file != NULL) {
-								// Get file size
-								fseek(file, 0, SEEK_END);
-								CoreModuleLen = ftell(file);
-								fseek(file, 0, SEEK_SET);
-
-								printf("[COREMODULE-2] File opened, size: %d bytes\n", CoreModuleLen);
-
-								// Allocate memory and read file
-								CoreModule = (char*)ILibMemory_Allocate(CoreModuleLen, 0, NULL, NULL);
-								if (CoreModule != NULL) {
-									printf("[COREMODULE-2] Memory allocated: %d bytes\n", CoreModuleLen);
-									size_t bytesRead = fread(CoreModule, 1, CoreModuleLen, file);
-									printf("[COREMODULE-2] Read %zu bytes from file\n", bytesRead);
-									if (bytesRead != CoreModuleLen) {
-										printf("[COREMODULE-2] ERROR: Read %zu bytes but expected %d\n", bytesRead, CoreModuleLen);
-										ILibMemory_Free(CoreModule);
-										CoreModule = NULL;
-										CoreModuleLen = 0;
-									} else {
-										printf("[COREMODULE-2] SUCCESS: CoreModule loaded from file (%d bytes)\n", CoreModuleLen);
-									}
-								} else {
-									printf("[COREMODULE-2] ERROR: Failed to allocate memory\n");
-								}
-								fclose(file);
-								printf("[COREMODULE-2] File closed\n");
-							} else {
-								printf("[COREMODULE-2] ERROR: Failed to open CoreModule file at: %s\n", coreModulePath);
-								CoreModule = NULL;
-								CoreModuleLen = 0;
-							}
-						}
-						else
-						{
-							printf("Use standard CoreModule from database\n");
-							CoreModule = (char*)ILibMemory_Allocate(CoreModuleLen, 0, NULL, NULL);
-							ILibSimpleDataStore_Get(agent->masterDb, "CoreModule", CoreModule, CoreModuleLen);
-						}
+						CoreModule = (char*)ILibMemory_Allocate(CoreModuleLen, 0, NULL, NULL);
+						ILibSimpleDataStore_Get(agent->masterDb, "CoreModule", CoreModule, CoreModuleLen);
 					}
 
-					printf("About to compile and execute CoreModule...\n");
 					if (ILibDuktape_ScriptContainer_CompileJavaScriptEx(agent->meshCoreCtx, CoreModule + 4, CoreModuleLen - 4, "CoreModule.js", 13) != 0 ||
 						ILibDuktape_ScriptContainer_ExecuteByteCode(agent->meshCoreCtx) != 0)
 					{
-						printf("ERROR executing CoreModule: %s\n", duk_safe_to_string(agent->meshCoreCtx, -1));
 						ILibRemoteLogging_printf(ILibChainGetLogger(agent->chain), ILibRemoteLogging_Modules_Microstack_Generic | ILibRemoteLogging_Modules_ConsolePrint,
 							ILibRemoteLogging_Flags_VerbosityLevel_1, "Error Executing MeshCore: %s", duk_safe_to_string(agent->meshCoreCtx, -1));
 						duk_pop(agent->meshCoreCtx);
-					}
-					else
-					{
-						printf("CoreModule executed successfully!\n");
 					}
 					free(CoreModule);
 				}
@@ -3866,7 +3712,7 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 			else
 			{
 				// There's no timeout, probably because the core is already running
-				printf("Meshcore already running (coreTimeout=%p)...\n", agent->coreTimeout);
+				printf(" meshcore already running...\n");
 			}
 			break;
 		}


### PR DESCRIPTION
## Why

OpenFrame agents currently execute a frozen disk `CoreModule.js` instead of the core the MeshCentral server pushes — the push is received, stored in the agent DB, and acked, but two `openFrameMode` branches substitute the disk file at execute time. That made core updates undeliverable (the disk file froze in an oss-lib JAR) and left a real inconsistency: the 60s offline-fallback executes the *DB* core, i.e. today the vanilla upstream core. This PR restores the stock upstream mechanism: the server compiles and pushes the core; the OpenFrame gateway URL patch now lives in the server's core source (flamingo-stack/meshcentral#73).

## What

`meshcore/agentcore.c`:
- **MeshCommand_CoreModule handler**: removed the openFrameMode branch that ran the disk file; the freshly received server core executes, as upstream.
- **CoreOk handler**: removed the openFrameMode disk-load branch; the DB core executes, as upstream. (This also removes a latent bug: the disk file was compiled with a +4 offset meant for DB blobs.)
- Removed the now-unused `buildOpenframeCoreModulePath()` helper and fork debug printfs (`[COREMODULE-2]`, pointer-printing CoreOk log). Restored regions verified byte-identical to `Ylianst/MeshAgent` upstream.
- **Kept** all other OpenFrame behavior: `mesh.authToken()`, control-channel auth header, binary self-update suppression, cert-rotation and NodeID relaxations.

## Rollout notes (order is load-bearing)

- **The server core (meshcentral#73) must be deployed before this binary rolls out in an environment.** A new binary against an unpatched server core would run stock upstream tunnel URLs and lose remote access. Old binaries against a patched server are safe (push stored, ignored).
- With an empty DB and no reachable server, no core runs until the first push — same as upstream, and same as before this change (the disk file was only ever executed from the push/CoreOk handlers).
- Supersedes the GitHub-release-asset approach (#79, to be closed after dev verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CoreModule startup and restart behavior is now consistent across environments.
  * CoreModule loading now reliably uses the database, including after server verification.
  * Updated status messages provide clearer information about restarts, verification, launches, and already-running states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->